### PR TITLE
Yanxin instan seg

### DIFF
--- a/nuclei_segmentation/instanseg/pipeline/centroids.py
+++ b/nuclei_segmentation/instanseg/pipeline/centroids.py
@@ -39,7 +39,15 @@ def _centroids_and_areas(label_tile: torch.Tensor) -> Tuple[torch.Tensor, torch.
     sum_y = torch.bincount(labels, weights=ys, minlength=minlength)
     sum_x = torch.bincount(labels, weights=xs, minlength=minlength)
     first_idx = torch.full((minlength,), flat.numel(), device=device, dtype=torch.long)
-    first_idx.scatter_reduce_(0, labels, coords, reduce="amin", include_self=True)
+    # scatter_reduce_ is not implemented on MPS; run on CPU then move back
+    if device.type == "mps":
+        first_idx_cpu = first_idx.cpu()
+        labels_cpu = labels.cpu()
+        coords_cpu = coords.cpu()
+        first_idx_cpu.scatter_reduce_(0, labels_cpu, coords_cpu, reduce="amin", include_self=True)
+        first_idx = first_idx_cpu.to(device)
+    else:
+        first_idx.scatter_reduce_(0, labels, coords, reduce="amin", include_self=True)
     seed_y = (first_idx // width).to(torch.float32)
     seed_x = (first_idx % width).to(torch.float32)
 

--- a/nuclei_segmentation/instanseg/segmentation_taskNode.py
+++ b/nuclei_segmentation/instanseg/segmentation_taskNode.py
@@ -39,6 +39,9 @@ from instanseg.pipeline import run_wsi
 # Import StarDist's PLIP-based embedding generator
 from nuc_embedding import NucleiEmbedding
 
+# Log Python and torch at startup so we can verify the correct env is used (e.g. torch>=2.6 for PLIP)
+print(f"[InstanSegNode] Python: {sys.executable}, torch: {torch.__version__}")
+
 app = FastAPI()
 
 # Add CORS middleware to allow cross-origin requests
@@ -127,6 +130,34 @@ def _read_streamed_vectors_from_zarr(
     except Exception as exc:
         print(f"[SEG LOG] Error reading streamed vectors from {zarr_path}: {exc}")
         return None, None, None
+
+
+def _get_userdata_signature(zarr_path: Optional[str], node_name: str) -> str:
+    """
+    Read userData from zarr and return a canonical string for comparison.
+    Any change in userData (any key or value) yields a different signature → re-run.
+    """
+    if not zarr_path or not os.path.exists(zarr_path):
+        return ""
+    try:
+        zf = zarr.open_group(zarr_path, mode="r")
+        user_data_path = f"{node_name}/userData"
+        if user_data_path not in zf:
+            return ""
+        d = {}
+        for k in sorted(zf[user_data_path].keys()):
+            raw = zf[user_data_path][k][()]
+            s = raw.decode("utf-8")
+            try:
+                val = json.loads(s)
+            except Exception:
+                val = s
+            d[k] = val
+        return json.dumps(d, sort_keys=True, ensure_ascii=False)
+    except Exception as e:
+        print(f"[SEG LOG] Warning: could not read userData for signature: {e}")
+        return ""
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -342,25 +373,61 @@ def run_segmentation(args):
 
         # ------------------------------------------------------------------
         # Step A: check if we already have segmentation results in Zarr
+        # userData different → re-run: compare full userData signature (any param change → re-run)
         # ------------------------------------------------------------------
         ALREADY_HAVE_SEG = False
         centroids = None          # slide-space centroids (what we store)
         contours = None           # slide-space contours (fixed-length after formatting)
         probability = None
 
+        current_signature = _get_userdata_signature(ZARR_PATH, NODE_NAME)
+
         if os.path.exists(ZARR_PATH):
-            centroids, contours, probability = _read_streamed_vectors_from_zarr(ZARR_PATH, NODE_NAME)
-            if centroids is not None and centroids.size > 0:
-                ALREADY_HAVE_SEG = True
-                result["message"] = "Using existing nuclei segmentation"
-                result["nuclei_count"] = len(centroids)
-                print(f"[SEG LOG] Using existing segmentation with {len(centroids)} nuclei")
-                update_progress(100, "segmentation")
+            zf = zarr.open_group(ZARR_PATH, mode='r')
+            if NODE_NAME in zf:
+                try:
+                    centroids = zf[f"{NODE_NAME}/centroids"][()] if f"{NODE_NAME}/centroids" in zf else None
+                    contours = zf[f"{NODE_NAME}/contours"][()] if f"{NODE_NAME}/contours" in zf else None
+                    probability = zf[f"{NODE_NAME}/probability"][()] if f"{NODE_NAME}/probability" in zf else None
+
+                    if centroids is not None and centroids.size > 0:
+                        node_grp = zf[NODE_NAME]
+                        saved_signature = node_grp.attrs.get("userData_signature", "")
+                        if saved_signature == current_signature:
+                            ALREADY_HAVE_SEG = True
+                            result["message"] = "Using existing nuclei segmentation"
+                            result["nuclei_count"] = len(centroids)
+                            print(f"[SEG LOG] Using existing segmentation with {len(centroids)} nuclei (userData unchanged)")
+                            update_progress(100, "segmentation")
+                        else:
+                            ALREADY_HAVE_SEG = False
+                            centroids = None
+                            contours = None
+                            probability = None
+                            print("[SEG LOG] userData different from last run → re-run InstanSeg.")
+                    else:
+                        ALREADY_HAVE_SEG = False
+                        centroids = None
+                        contours = None
+                        probability = None
+                        print(f"[SEG LOG] No existing centroids for '{NODE_NAME}' → will re-run InstanSeg.")
+                except KeyError as e:
+                    print(f"Warning: Existing segmentation data missing key {e}. Will re-run InstanSeg.")
+                    ALREADY_HAVE_SEG = False
+                    centroids = None
+                    contours = None
+                    probability = None
+                except Exception as e:
+                    print(f"Warning: Error reading existing segmentation data: {e}. Will re-run InstanSeg.")
+                    ALREADY_HAVE_SEG = False
+                    centroids = None
+                    contours = None
+                    probability = None
             else:
-                centroids = None
-                contours = None
-                probability = None
-                print(f"[SEG LOG] No existing streamed vectors for '{NODE_NAME}', will re-run InstanSeg.")
+                print(f"Group '{NODE_NAME}' not found in Zarr store. Will run InstanSeg.")
+                ALREADY_HAVE_SEG = False
+        else:
+            ALREADY_HAVE_SEG = False
 
         # ------------------------------------------------------------------
         # Step B: run InstanSeg if needed to obtain a label image
@@ -375,6 +442,20 @@ def run_segmentation(args):
 
             if MODEL is None:
                 raise ValueError("InstanSeg model not initialized. Call /init first.")
+
+            # Clear this node's segmentation data in zarr before re-run so the pipeline writer
+            # creates fresh datasets instead of appending to old (wrong) data
+            if ZARR_PATH and os.path.exists(ZARR_PATH):
+                try:
+                    zf = zarr.open_group(ZARR_PATH, mode="a")
+                    if NODE_NAME in zf:
+                        node_grp = zf[NODE_NAME]
+                        for key in ("centroids", "contours", "probability", "embedding"):
+                            if key in node_grp:
+                                del node_grp[key]
+                                print(f"[SEG LOG] Cleared existing '{key}' for re-run.")
+                except Exception as e:
+                    print(f"[SEG LOG] Warning: could not clear node data before re-run: {e}")
 
             inference_start = time.time()
             
@@ -410,6 +491,12 @@ def run_segmentation(args):
             result["message"] = "Segmentation completed successfully"
             result["nuclei_count"] = len(centroids)
 
+            # Save userData signature so next run can detect "userData different" and re-run if needed
+            zf = zarr.open_group(ZARR_PATH, mode='a')
+            node_grp = zf.require_group(NODE_NAME)
+            node_grp.attrs["userData_signature"] = current_signature
+            print(f"[ZARR WRITE] Saved userData_signature for re-run detection (any userData change → re-run)")
+
         # ------------------------------------------------------------------
         # Step C: ensure streamed data exists (writer already handled Zarr IO)
         # ------------------------------------------------------------------
@@ -428,27 +515,37 @@ def run_segmentation(args):
         if centroids is not None and len(centroids) > 0:
             zf = zarr.open_group(ZARR_PATH, mode='a')
             have_cached_embedding = False
-
-            if NODE_NAME in zf and 'embedding' in zf[NODE_NAME]:
-                try:
-                    existing_len = zf[NODE_NAME]['embedding'].shape[0]
-                    if existing_len == len(centroids):
-                        have_cached_embedding = True
-                        print("[EMBED LOG] Found existing embeddings in store => skip embedding calculation.")
-                except Exception:
-                    have_cached_embedding = False
+            # If segmentation was just re-run (ALREADY_HAVE_SEG == False), we must regenerate embedding
+            # because centroids have changed even if count is the same (same as StarDist)
+            if not ALREADY_HAVE_SEG:
+                print("[EMBED LOG] Segmentation was re-run, will regenerate embedding even if count matches")
+                have_cached_embedding = False
+            else:
+                if NODE_NAME in zf and 'embedding' in zf[NODE_NAME]:
+                    try:
+                        existing_len = zf[NODE_NAME]['embedding'].shape[0]
+                        if existing_len == len(centroids):
+                            have_cached_embedding = True
+                            print("[EMBED LOG] Found existing embeddings in store => skip embedding calculation.")
+                    except Exception:
+                        have_cached_embedding = False
 
             if not have_cached_embedding:
                 print("[EMBED LOG] No cached embeddings or size mismatch => generate new embeddings using StarDist PLIP model.")
 
-                # Load contours for bounding box extraction (optional, improves patch quality)
-                contours_for_embedding = None
-                if NODE_NAME in zf and 'contours' in zf[NODE_NAME]:
-                    try:
-                        contours_for_embedding = zf[f"{NODE_NAME}/contours"][()]
-                        print(f"[EMBED LOG] Loaded contours for embedding: shape {contours_for_embedding.shape}")
-                    except Exception as e:
-                        print(f"[EMBED LOG] Warning: Could not load contours for embedding: {e}")
+                # Use contours from current segmentation (in memory), not from zarr - same as StarDist
+                # This ensures contours match centroids count
+                contours_for_embedding = contours
+                if contours_for_embedding is not None:
+                    # contours can be (N, 32, 2) array; check first dimension
+                    n_contours = contours_for_embedding.shape[0] if hasattr(contours_for_embedding, 'shape') else len(contours_for_embedding)
+                    if n_contours != len(centroids):
+                        print(f"[EMBED LOG] Warning: Contours count ({n_contours}) doesn't match centroids count ({len(centroids)}) from current segmentation. Using None for contours.")
+                        contours_for_embedding = None
+                    else:
+                        print(f"[EMBED LOG] Using contours for embedding: shape {contours_for_embedding.shape}, centroids count: {len(centroids)}")
+                else:
+                    print("[EMBED LOG] Contours are None, embedding will use centroid-based patch extraction.")
 
                 embedding_start = time.time()
 

--- a/nuclei_segmentation/instanseg/segmentation_taskNode.py
+++ b/nuclei_segmentation/instanseg/segmentation_taskNode.py
@@ -132,18 +132,18 @@ def _read_streamed_vectors_from_zarr(
         return None, None, None
 
 
-def _get_userdata_signature(zarr_path: Optional[str], node_name: str) -> str:
+def _get_userdata_signature(zarr_path: Optional[str], node_name: str) -> Optional[str]:
     """
     Read userData from zarr and return a canonical string for comparison.
     Any change in userData (any key or value) yields a different signature → re-run.
     """
     if not zarr_path or not os.path.exists(zarr_path):
-        return ""
+        return None
     try:
         zf = zarr.open_group(zarr_path, mode="r")
         user_data_path = f"{node_name}/userData"
         if user_data_path not in zf:
-            return ""
+            return None
         d = {}
         for k in sorted(zf[user_data_path].keys()):
             raw = zf[user_data_path][k][()]
@@ -156,7 +156,7 @@ def _get_userdata_signature(zarr_path: Optional[str], node_name: str) -> str:
         return json.dumps(d, sort_keys=True, ensure_ascii=False)
     except Exception as e:
         print(f"[SEG LOG] Warning: could not read userData for signature: {e}")
-        return ""
+        return None
 
 
 def parse_args():
@@ -392,8 +392,24 @@ def run_segmentation(args):
 
                     if centroids is not None and centroids.size > 0:
                         node_grp = zf[NODE_NAME]
-                        saved_signature = node_grp.attrs.get("userData_signature", "")
-                        if saved_signature == current_signature:
+                        # Prefer new attr for last-run signature; fall back to legacy key
+                        saved_signature = node_grp.attrs.get("userData_signature_saved")
+                        if not saved_signature:
+                            saved_signature = node_grp.attrs.get("userData_signature", "")
+
+                        if not saved_signature:
+                            ALREADY_HAVE_SEG = False
+                            centroids = None
+                            contours = None
+                            probability = None
+                            print("[SEG LOG] Missing saved userData signature → re-run InstanSeg.")
+                        elif current_signature is None:
+                            ALREADY_HAVE_SEG = False
+                            centroids = None
+                            contours = None
+                            probability = None
+                            print("[SEG LOG] Could not read current userData signature → re-run InstanSeg.")
+                        elif saved_signature == current_signature:
                             ALREADY_HAVE_SEG = True
                             result["message"] = "Using existing nuclei segmentation"
                             result["nuclei_count"] = len(centroids)
@@ -491,11 +507,12 @@ def run_segmentation(args):
             result["message"] = "Segmentation completed successfully"
             result["nuclei_count"] = len(centroids)
 
-            # Save userData signature so next run can detect "userData different" and re-run if needed
-            zf = zarr.open_group(ZARR_PATH, mode='a')
-            node_grp = zf.require_group(NODE_NAME)
-            node_grp.attrs["userData_signature"] = current_signature
-            print(f"[ZARR WRITE] Saved userData_signature for re-run detection (any userData change → re-run)")
+            # Save last-run userData signature so next run can detect changes reliably
+            if current_signature is not None:
+                zf = zarr.open_group(ZARR_PATH, mode='a')
+                node_grp = zf.require_group(NODE_NAME)
+                node_grp.attrs["userData_signature_saved"] = current_signature
+                print("[ZARR WRITE] Saved userData_signature_saved for re-run detection (any userData change → re-run)")
 
         # ------------------------------------------------------------------
         # Step C: ensure streamed data exists (writer already handled Zarr IO)
@@ -766,6 +783,17 @@ def read_node(data: Dict[str, Any]):
                 else:
                     print(f"Warning: polygon_points value '{val_json}' is not in the expected [[x1,y1],[x2,y2],...] format.")
                     ARGS.polygon_points = None
+
+        # Persist the current userData signature so we can detect changes even if /execute runs later
+        current_signature = _get_userdata_signature(ZARR_PATH, NODE_NAME)
+        if current_signature is not None:
+            try:
+                zf_write = zarr.open_group(ZARR_PATH, mode='a')
+                node_grp = zf_write.require_group(NODE_NAME)
+                node_grp.attrs["userData_signature_current"] = current_signature
+                print("[ZARR WRITE] Saved userData_signature_current at /read")
+            except Exception as e:
+                print(f"[SEG LOG] Warning: could not save userData_signature_current at /read: {e}")
 
     return {"status": "ok", "message": "InstanSegNode read done"}
 


### PR DESCRIPTION
## 🔍 InstanSeg Pipeline Updates

This PR covers the **latest two rounds of updates** in Model-Zoo for InstanSeg:
1) **Pipeline improvements + smarter reuse/embedding logic** (InstanSeg integration changes)
2) **Robust userData signature handling** (edge-case fixes)

It ensures segmentation/embedding reuse is safe, and that re-run decisions are consistent when user parameters change.

---

### 🐛 Previous Behavior & Issues

There were two classes of problems:

1) **Reuse logic lacked full user-parameter awareness**  
   - Existing centroids could be reused without reliable detection of userData changes.
   - Embeddings could be reused even after segmentation was re-run (if count matched).

2) **Signature edge cases**  
   - Missing or unreadable userData was treated as empty string.
   - Empty string could falsely match a saved signature → **skip re-run incorrectly**.

**Problem scenarios:**
- `userData` missing or unreadable → signature becomes `""` → accidentally equals saved `""` → **skip incorrectly**
- Old data without saved signature → treated as empty → **skip incorrectly**
- Segmentation re-run but embedding reused because counts matched → **mismatch risk**

---

### ✅ What I Changed

#### A) InstanSeg pipeline & reuse improvements (earlier change)

Key changes:
- **Re-run detection uses userData signature** (not only presence of centroids).  
- **Clear old datasets before re-run** to avoid mixing old/new results: `centroids`, `contours`, `probability`, `embedding`.  
- **Embedding regeneration** is forced when segmentation was re-run (even if counts match).  
- **Contours for embedding** come from current in-memory segmentation results (avoids stale contours).

#### B) userData signature edge-case fixes (latest change)

##### 1) Signature read now returns `None` on failure
If `userData` is missing or unreadable, we now return `None` (not `""`).

```python
# _get_userdata_signature()
if not zarr_path or not os.path.exists(zarr_path):
    return None
...
if user_data_path not in zf:
    return None
...
except Exception as e:
    print(...)
    return None
```

##### 2) Missing/failed signature → **force re-run**
We now explicitly re-run when:
- `saved_signature` is missing
- `current_signature` is `None`

```python
if not saved_signature:
    re-run
elif current_signature is None:
    re-run
elif saved_signature == current_signature:
    reuse
else:
    re-run
```

##### 3) Split “current” vs “saved” signatures
- `userData_signature_current` → written during `/read`
- `userData_signature_saved` → written after segmentation completes

This prevents a case where new userData is written but old segmentation is still reused.

```python
# /read
node_grp.attrs["userData_signature_current"] = current_signature

# after segmentation
node_grp.attrs["userData_signature_saved"] = current_signature
```

---

### ✅ Where This Lives

- `nuclei_segmentation/instanseg/segmentation_taskNode.py`
  - `_get_userdata_signature()` updated
  - Re-run decision logic updated in **Step A**
  - `/read` writes `userData_signature_current`
  - Segmentation run writes `userData_signature_saved`
  - Re-run clears old datasets before new run
  - Embedding regeneration logic updated

---

### 📹 Demo Recording

[Demo Video](https://drive.google.com/file/d/12YGCLBPFAbiq53gkFKAfdBz4ljmZLb7v/view?usp=drive_link)
