### PR TITLE
Embed source image name and user_annotation log on classifier save

### DIFF
--- a/cell_classification/NuClass/classification_taskNode.py
+++ b/cell_classification/NuClass/classification_taskNode.py
@@ -719,6 +719,44 @@ def save_classifier_params(clf, class_names, class_colors, train_data, max_sampl
     train_data_str = base64.b64encode(train_data_bytes.getvalue()).decode('utf-8')
     booster.set_attr(train_data=train_data_str)
 
+    # Provenance: also persist the source image name and the per-cell
+    # user_annotation rows into the booster. Each save merges in only rows new
+    # to the booster's existing log, so it grows incrementally across an
+    # iterative training session rather than re-bundling the full zarr
+    # annotation set every save. A relabel of the same cell_id (different
+    # class/annotator) is kept as a separate record so the history is
+    # preserved. Non-fatal on error since the classifier itself is the
+    # critical artifact.
+    try:
+        zf_prov = zarr.open_group(ZARR_PATH, mode='r')
+        image_name = os.path.basename(str(ZARR_PATH).rstrip('/')).removesuffix('.zarr')
+        prev_image_names = json.loads(booster.attr('image_names') or '[]')
+        if image_name and image_name not in prev_image_names:
+            prev_image_names.append(image_name)
+        booster.set_attr(image_names=json.dumps(prev_image_names))
+        if 'user_annotation/nuclei_annotations' in zf_prov:
+            current = zf_prov['user_annotation/nuclei_annotations'][()]
+            prev_attr = booster.attr('user_annotations')
+            if prev_attr:
+                prev_buf = io.BytesIO(base64.b64decode(prev_attr))
+                prev = np.load(prev_buf, allow_pickle=False)['records']
+            else:
+                prev = np.empty(0, dtype=current.dtype)
+            seen = set()
+            merged_list = []
+            for row in np.concatenate([prev, current]):
+                key = tuple(row.tolist())
+                if key not in seen:
+                    seen.add(key)
+                    merged_list.append(row)
+            merged = (np.array(merged_list, dtype=current.dtype)
+                      if merged_list else np.empty(0, dtype=current.dtype))
+            log_buf = io.BytesIO()
+            np.savez_compressed(log_buf, records=merged)
+            booster.set_attr(user_annotations=base64.b64encode(log_buf.getvalue()).decode('utf-8'))
+    except Exception as e:
+        print(f"[ClassificationNode] Skipping user_annotation provenance embed: {e}")
+
     LAST_TRAINED_CLF_BUNDLE = (clf, class_names, class_colors, train_data)
 
     if SAVE_CLASSIFIER_PATH:
@@ -758,7 +796,19 @@ def load_classifier_params(zarr_path):
         if not os.path.exists(CLASSIFIER_PATH):
             print(f"XGBoost model file not found at: {CLASSIFIER_PATH}")
             return None
-            
+
+        # An empty placeholder file is created by the frontend BEFORE training;
+        # if training never runs (or the path got cleared), it stays 0 bytes.
+        # Treat that as "no usable classifier" so callers fall back to training
+        # from annotations instead of crashing inside xgb.load_model with
+        # "BoostLearner: wrong model format".
+        try:
+            if os.path.getsize(CLASSIFIER_PATH) == 0:
+                print(f"Classifier file is empty (0 bytes), skipping load: {CLASSIFIER_PATH}")
+                return None
+        except OSError:
+            pass
+
         clf = xgb.XGBClassifier()
         clf.load_model(CLASSIFIER_PATH)
         

--- a/cell_classification/NuClass/classification_taskNode.py
+++ b/cell_classification/NuClass/classification_taskNode.py
@@ -736,6 +736,19 @@ def save_classifier_params(clf, class_names, class_colors, train_data, max_sampl
         booster.set_attr(image_names=json.dumps(prev_image_names))
         if 'user_annotation/nuclei_annotations' in zf_prov:
             current = zf_prov['user_annotation/nuclei_annotations'][()]
+            # The dataset has one row per cell with `cell_class == -1` for
+            # unannotated placeholders. Keep only rows the classifier actually
+            # trains on, matching load_structured_nuclei_annotations: positives
+            # (cell_class >= 0) and negatives (cell_class <= -2), all with
+            # cell_color >= 0. On large slides this cuts ~165k rows to a few
+            # hundred, making the per-save dedup loop fast and stopping the
+            # log from being bloated with empty placeholder records.
+            if {'cell_class', 'cell_color'}.issubset(current.dtype.names or ()):
+                meaningful = (
+                    ((current['cell_class'] >= 0) | (current['cell_class'] <= -2))
+                    & (current['cell_color'] >= 0)
+                )
+                current = current[meaningful]
             prev_attr = booster.attr('user_annotations')
             if prev_attr:
                 prev_buf = io.BytesIO(base64.b64decode(prev_attr))

--- a/patch_classification/MUSK/model/requirements.txt
+++ b/patch_classification/MUSK/model/requirements.txt
@@ -15,7 +15,7 @@ ftfy
 opencv-python
 sentencepiece
 pyarrow
-transformers
+transformers<5
 pytorch-lightning==2.2.1
 nltk
 rouge

--- a/patch_classification/MUSK/musk_classification_tasknode.py
+++ b/patch_classification/MUSK/musk_classification_tasknode.py
@@ -269,6 +269,37 @@ def save_classifier_params(clf, class_names, class_colors, train_data, max_sampl
     train_data_str = base64.b64encode(train_data_bytes.getvalue()).decode('utf-8')
     booster.set_attr(train_data=train_data_str)
 
+    # Provenance: also persist the source image name and the per-patch
+    # user_annotation entries into the booster. Each save merges in only
+    # entries new to the booster's existing log, so it grows incrementally
+    # across an iterative training session rather than re-bundling the full
+    # zarr annotation set every save. A relabel of the same patch (different
+    # value) is kept as a separate record so the history is preserved.
+    # Non-fatal on error since the classifier itself is the critical artifact.
+    try:
+        zf_prov = zarr.open_group(ZARR_PATH, mode='r')
+        image_name = os.path.basename(str(ZARR_PATH).rstrip('/')).removesuffix('.zarr')
+        prev_image_names = json.loads(booster.attr('image_names') or '[]')
+        if image_name and image_name not in prev_image_names:
+            prev_image_names.append(image_name)
+        booster.set_attr(image_names=json.dumps(prev_image_names))
+        if 'user_annotation' in zf_prov and 'tissue_annotations' in zf_prov['user_annotation']:
+            raw = zf_prov['user_annotation/tissue_annotations'][()]
+            current_dict = json.loads(raw.decode('utf-8'))
+            current_records = [
+                [pid, json.dumps(val, sort_keys=True)]
+                for pid, val in current_dict.items()
+            ]
+            prev_records = json.loads(booster.attr('user_annotations') or '[]')
+            seen = {tuple(r) for r in prev_records}
+            for r in current_records:
+                if tuple(r) not in seen:
+                    prev_records.append(r)
+                    seen.add(tuple(r))
+            booster.set_attr(user_annotations=json.dumps(prev_records))
+    except Exception as e:
+        print(f"[MuskClassificationNode] Skipping user_annotation provenance embed: {e}")
+
     LAST_TRAINED_CLF_BUNDLE = (clf, class_names, class_colors, train_data)
 
     if SAVE_CLASSIFIER_PATH:
@@ -308,7 +339,17 @@ def load_classifier_params():
         if not os.path.exists(CLASSIFIER_PATH):
             print(f"XGBoost model file not found at: {CLASSIFIER_PATH}")
             return None
-            
+
+        # Empty placeholder created by the frontend Save flow stays 0 bytes if
+        # training never completes; treat it as "no usable classifier" so we
+        # don't crash inside xgb.load_model with wrong model format.
+        try:
+            if os.path.getsize(CLASSIFIER_PATH) == 0:
+                print(f"Classifier file is empty (0 bytes), skipping load: {CLASSIFIER_PATH}")
+                return None
+        except OSError:
+            pass
+
         clf = xgb.XGBClassifier()
         clf.load_model(CLASSIFIER_PATH)
         


### PR DESCRIPTION
## Summary
  - In `save_classifier_params` for both NuClass (nuclei) and MUSK (patch), persist `image_names` and `user_annotations`
  into the booster as new attrs. Each save merges in only rows new to the booster log (full-row dedup), so it grows 
  incrementally across an iterative training session and preserves relabel history (same `cell_id`/`patch_id` with a 
  different class or annotator is kept as a separate record). Embed is wrapped in try/except so a provenance failure 
  never breaks the classifier save itself.
  - Also pins `transformers<5` in `MUSK/model/requirements.txt` to match the same pin already in 
  `MUSK/requirements.txt`.
  - NuClass perf: drop placeholder rows (`cell_class == -1`) before dedup. The dataset stores one row per cell (~165k on
  a typical slide); filtering to rows the classifier actually trains on (mirrors `load_structured_nuclei_annotations`) 
  cuts the loop to a few hundred and stops the embedded log from being bloated with empty records.

  ## Test plan
  - [ ] Train a NuClass classifier; inspect the .tlcls and confirm new attrs `image_names` and `user_annotations` are 
  present, and `user_annotations` only contains real annotation rows.
  - [ ] Train MUSK; same attrs present on its .tlcls.
  - [ ] Train twice in the same session; the embedded annotation log accumulates (only new rows added across saves).