### PR TITLE
Update to Zarr3 - Model Zoo

### DIFF
--- a/cell_classification/NuClass/classification_taskNode.py
+++ b/cell_classification/NuClass/classification_taskNode.py
@@ -59,6 +59,12 @@ import uvicorn
 import xgboost as xgb
 import zarr
 from fastapi import FastAPI
+
+# Silence zarr v3 "unstable data type" warnings (structured arrays + fixed-length
+# string/bytes dtypes used by our schema). No cross-library portability needed.
+import warnings
+from zarr.errors import UnstableSpecificationWarning
+warnings.filterwarnings("ignore", category=UnstableSpecificationWarning)
 from fastapi.middleware.cors import CORSMiddleware
 from sse_starlette.sse import EventSourceResponse
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -539,7 +545,7 @@ def _annotation_labels_to_classifier_indices(annotations, class_names, nuclei_cl
 def print_h5_structure(file_path):
     """Print Zarr group structure"""
     def _visit(group, prefix=""):
-        for key, val in group.items():
+        for key, val in group.members():
             name = f"{prefix}/{key}" if prefix else key
             if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")

--- a/cell_classification/NuClass/classification_taskNode.py
+++ b/cell_classification/NuClass/classification_taskNode.py
@@ -280,7 +280,7 @@ def _persist_nuclei_rename_to_user_annotation(zf, effective_renames, nuclei_clas
                 del ua["cell_class_counts"]
             except KeyError:
                 pass
-            ua.create_dataset("cell_class_counts", data=out_bytes)
+            ua.create_array("cell_class_counts", data=np.array(out_bytes, dtype=f"S{len(out_bytes)}"))
             print(f"[Cell-Classification] Remapped User-Annotations/cell/__attrs_class_counts__ after rename: {new_counts}")
 
     # 2) Sync attrs class_names / class_colors with workflow (preferred) or apply rename chain
@@ -541,7 +541,7 @@ def print_h5_structure(file_path):
     def _visit(group, prefix=""):
         for key, val in group.items():
             name = f"{prefix}/{key}" if prefix else key
-            if isinstance(val, zarr.hierarchy.Group):
+            if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")
                 _visit(val, name)
             else:
@@ -1898,15 +1898,15 @@ def run_classification(args) -> Dict[str, Any]:
             del zf[ZARR_GROUP]
         grp_cls = zf.require_group(ZARR_GROUP)
 
-        grp_cls.create_dataset('class_indices', data=predictions.astype(np.int32))
+        grp_cls.create_array('class_indices', data=predictions.astype(np.int32))
 
         # Per-class taxonomy: classes/{index, name, color} parallel arrays.
         classes_grp = grp_cls.require_group('classes')
-        classes_grp.create_dataset('index', data=np.arange(len(final_class_names), dtype=np.int32))
+        classes_grp.create_array('index', data=np.arange(len(final_class_names), dtype=np.int32))
         class_names_ascii = np.array([n.encode('utf-8') for n in final_class_names], dtype='S256')
-        classes_grp.create_dataset('name', data=class_names_ascii)
+        classes_grp.create_array('name', data=class_names_ascii)
         colors_ascii = np.array([c.encode('utf-8') for c in final_class_colors], dtype='S256')
-        classes_grp.create_dataset('color', data=colors_ascii)
+        classes_grp.create_array('color', data=colors_ascii)
 
         # Update all annotation colors to match new class colors
         # This ensures that when user changes a class color and clicks Update,
@@ -1949,9 +1949,7 @@ def run_classification(args) -> Dict[str, Any]:
                         # Write updated annotations back
                         # Note: We need to delete and recreate the dataset to update it
                         del zf['User-Annotations/cell']
-                        zf['User-Annotations'].create_dataset('cell', data=all_annotations, 
-                                                             dtype=annotations_dataset.dtype, 
-                                                             shape=annotations_dataset.shape)
+                        zf['User-Annotations'].create_array('cell', data=all_annotations)
                         print(f"Updated {updated_count} annotation colors to match new class colors")
         except Exception as e:
             # If update fails, log but don't fail the workflow
@@ -1973,7 +1971,7 @@ def run_classification(args) -> Dict[str, Any]:
 
         # Save probability scores for active learning
         if prediction_probs is not None:
-            grp_cls.create_dataset('probabilities', data=prediction_probs.astype(np.float32))
+            grp_cls.create_array('probabilities', data=prediction_probs.astype(np.float32))
             print(f"Saved classification probabilities for active learning, shape: {prediction_probs.shape}")
         elif classification_method == "zero-shot" and 'sims_arr' in locals() and sims_arr is not None:
             # For zero-shot: save similarity scores as pseudo-probabilities
@@ -1981,7 +1979,7 @@ def run_classification(args) -> Dict[str, Any]:
             print(f"Converting similarity scores to probabilities, shape: {sims_arr.shape}")
             exp_sims = np.exp(sims_arr - np.max(sims_arr, axis=1, keepdims=True))
             pseudo_probs = exp_sims / np.sum(exp_sims, axis=1, keepdims=True)
-            grp_cls.create_dataset('probabilities', data=pseudo_probs.astype(np.float32))
+            grp_cls.create_array('probabilities', data=pseudo_probs.astype(np.float32))
             print(f"Saved zero-shot similarity scores as probabilities for active learning, shape: {pseudo_probs.shape}")
         else:
             print("Warning: No probability data available to save for active learning")
@@ -2206,13 +2204,13 @@ def read_node(data: Dict[str, Any]):
 
 def _user_data_write_json(zarr_path: str, node_name: str, key: str, payload: Any) -> None:
     """Persist one key under {node_name}/userData (JSON bytes), matching tasks_service /read layout."""
-    with zarr.open_group(zarr_path, mode="a") as zf:
-        grp_path = f"{node_name}/userData"
-        grp = zf.require_group(grp_path)
-        if key in grp:
-            del grp[key]
-        raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-        grp.create_dataset(key, shape=(), dtype=f"S{len(raw)}", data=raw)
+    zf = zarr.open_group(zarr_path, mode="a")
+    grp_path = f"{node_name}/userData"
+    grp = zf.require_group(grp_path)
+    if key in grp:
+        del grp[key]
+    raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    grp.create_array(key, data=np.array(raw, dtype=f"S{len(raw)}"))
 
 
 @app.post("/classifier/load")

--- a/cell_classification/NuClass/requirements.txt
+++ b/cell_classification/NuClass/requirements.txt
@@ -6,7 +6,7 @@ opencv-python==4.6.0.66
 scipy==1.11.0
 tiffslide==1.5.0
 multiprocess==0.70.17
-zarr==2.17.2
+zarr==3.1.5
 # Match the cloud stardist env. Keep xgboost in the 2.0–3.0 range: these load
 # the legacy `binf` classifiers AND rebuild XGBClassifier.n_classes_ from the
 # booster on load. 1.7.x loads binf but does NOT rebuild n_classes_ (breaks

--- a/nuclei_segmentation/CellPose/cellpose_tasknode.py
+++ b/nuclei_segmentation/CellPose/cellpose_tasknode.py
@@ -125,7 +125,7 @@ def print_h5_structure(file_path):
     def _visit(group, prefix=""):
         for key, val in group.items():
             name = f"{prefix}/{key}" if prefix else key
-            if isinstance(val, zarr.hierarchy.Group):
+            if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")
                 _visit(val, name)
             else:
@@ -229,11 +229,11 @@ def run_segmentation(args):
                 del zf[NODE_NAME]
             node_grp = zf.create_group(NODE_NAME)
 
-            node_grp.create_dataset('centroids', data=centroids)
+            node_grp.create_array('centroids', data=centroids)
             if contours is not None:
-                node_grp.create_dataset('contours', data=contours)
+                node_grp.create_array('contours', data=contours)
             if not ALREADY_HAVE_SEG and 'probabilities' in locals():
-                node_grp.create_dataset('probabilities', data=probability)
+                node_grp.create_array('probabilities', data=probability)
 
         # Ensure progress is set to 100 after Step C and D are completed
         progress_complete = True
@@ -366,7 +366,7 @@ def execute_node():
             del zf[node_out_path]
         out_str = json.dumps(out_val, ensure_ascii=False)
         out_bytes = out_str.encode("utf-8")
-        zf.create_dataset(node_out_path, shape=(), dtype=f'S{len(out_bytes)}', data=out_bytes)
+        zf.create_array(node_out_path, data=np.array(out_bytes, dtype=f'S{len(out_bytes)}'))
 
     return {"status": "ok", "output": out_val}
 

--- a/nuclei_segmentation/CellPose/cellpose_tasknode.py
+++ b/nuclei_segmentation/CellPose/cellpose_tasknode.py
@@ -10,6 +10,12 @@ import json
 import threading
 import zarr
 import uvicorn
+
+# Silence zarr v3 "unstable data type" warnings (structured arrays + fixed-length
+# string/bytes dtypes used by our schema). No cross-library portability needed.
+import warnings
+from zarr.errors import UnstableSpecificationWarning
+warnings.filterwarnings("ignore", category=UnstableSpecificationWarning)
 import requests
 import platform
 import numpy as np
@@ -123,7 +129,7 @@ def parse_args():
 def print_h5_structure(file_path):
     """Helper to print Zarr structure."""
     def _visit(group, prefix=""):
-        for key, val in group.items():
+        for key, val in group.members():
             name = f"{prefix}/{key}" if prefix else key
             if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")

--- a/nuclei_segmentation/CellPose/nuc_embedding_mac.py
+++ b/nuclei_segmentation/CellPose/nuc_embedding_mac.py
@@ -343,11 +343,12 @@ class NucleiEmbedding:
         ds_name = parts[-1]
         if ds_name in parent:
             del parent[ds_name]
-        embeddings_dset = parent.create_dataset(
+        embeddings_dset = parent.create_array(
             ds_name,
             shape=(0, 768),
             chunks=(min(1000, batch_size), 768),
-            dtype=np.float16
+            dtype=np.float16,
+            overwrite=True
         )
         
         total_start_time = time.time()

--- a/nuclei_segmentation/StarDist/nuc_embedding.py
+++ b/nuclei_segmentation/StarDist/nuc_embedding.py
@@ -3418,11 +3418,12 @@ class NucleiEmbedding:
                 dataset.z_layer = layer_idx
 
                 # Create temporary dataset for this layer
-                layer_dset = parent.create_dataset(
+                layer_dset = parent.create_array(
                     f'_temp_layer_{layer_idx}',
                     shape=(num_cells, 768),
                     chunks=(min(1000, batch_size), 768),
-                    dtype=np.float16
+                    dtype=np.float16,
+                    overwrite=True
                 )
 
                 # Process this layer
@@ -3509,11 +3510,12 @@ class NucleiEmbedding:
             fusion_start_time = time.time()
             
             # Create final dataset
-            final_dset = parent.create_dataset(
+            final_dset = parent.create_array(
                 ds_name,
                 shape=(num_cells, 768),
                 chunks=(min(1000, batch_size), 768),
-                dtype=np.float16
+                dtype=np.float16,
+                overwrite=True
             )
             
             # Fuse by averaging across layers for each cell
@@ -3583,11 +3585,12 @@ class NucleiEmbedding:
             # Write sequentially (in new index order) first, then reorder at the end
             # This provides the performance benefit of sequential writes
         
-        embeddings_dset = parent.create_dataset(
+        embeddings_dset = parent.create_array(
             ds_name,
             shape=(len(dataset), 768) if need_reorder else (0, 768),
             chunks=(min(1000, batch_size), 768),
-            dtype=np.float16
+            dtype=np.float16,
+            overwrite=True
         )
         pbar = tqdm(total=len(dataset), desc="Generating embeddings")
         

--- a/nuclei_segmentation/StarDist/segmentation_taskNode.py
+++ b/nuclei_segmentation/StarDist/segmentation_taskNode.py
@@ -390,13 +390,13 @@ def run_segmentation(args):
             print(f"[ZARR WRITE] Writing centroids. Shape: {centroids_data.shape}")
             if 'centroids' in node_grp:
                 del node_grp['centroids']
-            node_grp.create_dataset('centroids', data=centroids_data)
+            node_grp.create_array('centroids', data=centroids_data)
 
             if contours_data is not None:
                 print(f"[ZARR WRITE] Writing contours. Shape: {contours_data.shape}")
                 if 'contours' in node_grp:
                     del node_grp['contours']
-                node_grp.create_dataset('contours', data=contours_data)
+                node_grp.create_array('contours', data=contours_data)
             else:
                 print("[ZARR WRITE] Contours are None, not writing.")
 
@@ -404,7 +404,7 @@ def run_segmentation(args):
                 print(f"[ZARR WRITE] Writing probability. Shape: {probability_data.shape}")
                 if 'probabilities' in node_grp:
                     del node_grp['probabilities']
-                node_grp.create_dataset('probabilities', data=probability_data)
+                node_grp.create_array('probabilities', data=probability_data)
             else:
                 print("[ZARR WRITE] Probability is None, not writing.")
 

--- a/nuclei_segmentation/StarDist/segmentation_taskNode.py
+++ b/nuclei_segmentation/StarDist/segmentation_taskNode.py
@@ -28,6 +28,12 @@ import torch
 import uvicorn
 import zarr
 from fastapi import FastAPI
+
+# Silence zarr v3 "unstable data type" warnings (structured arrays + fixed-length
+# string/bytes dtypes used by our schema). No cross-library portability needed.
+import warnings
+from zarr.errors import UnstableSpecificationWarning
+warnings.filterwarnings("ignore", category=UnstableSpecificationWarning)
 from fastapi.middleware.cors import CORSMiddleware
 from sse_starlette.sse import EventSourceResponse
 from starlette.middleware.base import BaseHTTPMiddleware

--- a/nuclei_segmentation/instanseg/environment.yml
+++ b/nuclei_segmentation/instanseg/environment.yml
@@ -33,7 +33,7 @@ dependencies:
     - rasterio>=1.3.0  # For geojson export
     
     # Data Storage
-    - zarr>=2.14.0
+    - zarr==3.1.5
     
     # Web Framework
     - fastapi>=0.104.0

--- a/nuclei_segmentation/instanseg/nuc_embedding.py
+++ b/nuclei_segmentation/instanseg/nuc_embedding.py
@@ -3392,7 +3392,7 @@ class NucleiEmbedding:
                 dataset.z_layer = layer_idx
 
                 # Create temporary dataset for this layer
-                layer_dset = parent.create_dataset(
+                layer_dset = parent.create_array(
                     f'_temp_layer_{layer_idx}',
                     shape=(num_cells, 768),
                     chunks=(min(1000, batch_size), 768),
@@ -3483,7 +3483,7 @@ class NucleiEmbedding:
             fusion_start_time = time.time()
             
             # Create final dataset
-            final_dset = parent.create_dataset(
+            final_dset = parent.create_array(
                 ds_name,
                 shape=(num_cells, 768),
                 chunks=(min(1000, batch_size), 768),
@@ -3557,7 +3557,7 @@ class NucleiEmbedding:
             # Write sequentially (in new index order) first, then reorder at the end
             # This provides the performance benefit of sequential writes
         
-        embeddings_dset = parent.create_dataset(
+        embeddings_dset = parent.create_array(
             ds_name,
             shape=(len(dataset), 768) if need_reorder else (0, 768),
             chunks=(min(1000, batch_size), 768),

--- a/nuclei_segmentation/instanseg/pipeline/writer.py
+++ b/nuclei_segmentation/instanseg/pipeline/writer.py
@@ -34,11 +34,10 @@ class _StreamingSegmentationWriter:
             if self.verbose:
                 print(f"[WRITER] Reusing existing centroids dataset: {self.count} nuclei")
         else:
-            self.centroids_ds = self._group.create_dataset(
+            self.centroids_ds = self._group.create_array(
                 "centroids",
                 shape=(0, 2),
                 chunks=(8192, 2),
-                maxshape=(None, 2),
                 dtype="i4",
             )
             self.count = 0
@@ -56,12 +55,10 @@ class _StreamingSegmentationWriter:
         ds = getattr(self, attr_name)
         if ds is None:
             chunks = (min(8192, max(1, data.shape[0])),) + data.shape[1:]
-            maxshape = (None,) + data.shape[1:]
-            ds = self._group.create_dataset(
+            ds = self._group.create_array(
                 name,
                 shape=(0,) + data.shape[1:],
                 chunks=chunks,
-                maxshape=maxshape,
                 dtype=data.dtype,
             )
             setattr(self, attr_name, ds)
@@ -93,5 +90,5 @@ class _StreamingSegmentationWriter:
     def write_probabilities(self, probabilities: np.ndarray):
         if "probabilities" in self._group:
             del self._group["probabilities"]
-        self._group.create_dataset("probabilities", data=probabilities.astype(np.float32))
+        self._group.create_array("probabilities", data=probabilities.astype(np.float32))
 

--- a/nuclei_segmentation/instanseg/requirements.txt
+++ b/nuclei_segmentation/instanseg/requirements.txt
@@ -33,7 +33,7 @@ rasterio>=1.3.0
 pydicom  # For DICOM file support
 
 # Data Storage
-zarr>=2.14.0
+zarr==3.1.5
 
 # Web Framework
 fastapi>=0.104.0

--- a/nuclei_segmentation/instanseg/segmentation_taskNode.py
+++ b/nuclei_segmentation/instanseg/segmentation_taskNode.py
@@ -31,6 +31,12 @@ import torch
 import uvicorn
 import zarr
 from fastapi import FastAPI
+
+# Silence zarr v3 "unstable data type" warnings (structured arrays + fixed-length
+# string/bytes dtypes used by our schema). No cross-library portability needed.
+import warnings
+from zarr.errors import UnstableSpecificationWarning
+warnings.filterwarnings("ignore", category=UnstableSpecificationWarning)
 from fastapi.middleware.cors import CORSMiddleware
 from sse_starlette.sse import EventSourceResponse
 from tiffslide import TiffSlide

--- a/patch_classification/H-optimus-0/hoptimus_classification_tasknode.py
+++ b/patch_classification/H-optimus-0/hoptimus_classification_tasknode.py
@@ -27,6 +27,12 @@ import time
 import json
 import zarr
 import uvicorn
+
+# Silence zarr v3 "unstable data type" warnings (structured arrays + fixed-length
+# string/bytes dtypes used by our schema). No cross-library portability needed.
+import warnings
+from zarr.errors import UnstableSpecificationWarning
+warnings.filterwarnings("ignore", category=UnstableSpecificationWarning)
 import requests
 import numpy as np
 import pandas as pd
@@ -196,7 +202,7 @@ def _normalize_class_operations(raw_ops):
 def print_zarr_structure(file_path):
     """print Zarr store"""
     def _visit(group, prefix=""):
-        for key, val in group.items():
+        for key, val in group.members():
             name = f"{prefix}/{key}" if prefix else key
             if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")

--- a/patch_classification/H-optimus-0/hoptimus_classification_tasknode.py
+++ b/patch_classification/H-optimus-0/hoptimus_classification_tasknode.py
@@ -198,7 +198,7 @@ def print_zarr_structure(file_path):
     def _visit(group, prefix=""):
         for key, val in group.items():
             name = f"{prefix}/{key}" if prefix else key
-            if isinstance(val, zarr.hierarchy.Group):
+            if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")
                 _visit(val, name)
             else:
@@ -1594,24 +1594,24 @@ def run_classification(args) -> Dict[str, Any]:
             del zf[ZARR_GROUP]
         grp_cls = zf.create_group(ZARR_GROUP)
 
-        grp_cls.create_dataset('class_indices', data=predictions.astype(np.int32))
+        grp_cls.create_array('class_indices', data=predictions.astype(np.int32))
 
         # Persist per-patch class probabilities so downstream (patch review /
         # active learning) can do threshold + uncertainty filtering.
         # prediction_probs is (n_patches, n_classes); None in zero-shot mode.
         if prediction_probs is not None:
-            grp_cls.create_dataset(
+            grp_cls.create_array(
                 'probabilities',
                 data=np.asarray(prediction_probs, dtype=np.float32),
             )
 
         # Per-class taxonomy under classes/{index, name, color}.
         classes_grp = grp_cls.require_group('classes')
-        classes_grp.create_dataset('index', data=np.arange(len(final_class_names), dtype=np.int32))
+        classes_grp.create_array('index', data=np.arange(len(final_class_names), dtype=np.int32))
         class_names_ascii = [n.encode('utf-8') for n in final_class_names]
-        classes_grp.create_dataset('name', shape=(len(class_names_ascii),), dtype='S256', data=class_names_ascii)
+        classes_grp.create_array('name', shape=(len(class_names_ascii),), dtype='S256', data=class_names_ascii)
         colors_ascii = [c.encode('utf-8') for c in final_class_colors]
-        classes_grp.create_dataset('color', shape=(len(colors_ascii),), dtype='S256', data=colors_ascii)
+        classes_grp.create_array('color', shape=(len(colors_ascii),), dtype='S256', data=colors_ascii)
 
         # Update all annotation colors to match new class colors
         # This ensures that when user changes a class color and clicks Update,
@@ -1641,7 +1641,7 @@ def run_classification(args) -> Dict[str, Any]:
                                 updated_count += 1
                     if updated_count > 0:
                         del zf['User-Annotations/patch']
-                        zf['User-Annotations'].create_dataset('patch', data=patch_arr, dtype=patch_arr.dtype)
+                        zf['User-Annotations'].create_array('patch', data=patch_arr, dtype=patch_arr.dtype)
                         print(f"Updated {updated_count} patch annotation colors to match new class colors")
         except Exception as e:
             # If update fails, log but don't fail the workflow.
@@ -2024,13 +2024,13 @@ def read_node(data: Dict[str, Any]):
 
 def _user_data_write_json(zarr_path: str, node_name: str, key: str, payload: Any) -> None:
     """Persist one key under {node_name}/userData (JSON bytes), matching tasks_service /read layout."""
-    with zarr.open_group(zarr_path, mode="a") as zf:
-        grp_path = f"{node_name}/userData"
-        grp = zf.require_group(grp_path)
-        if key in grp:
-            del grp[key]
-        raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-        grp.create_dataset(key, shape=(), dtype=f"S{len(raw)}", data=raw)
+    zf = zarr.open_group(zarr_path, mode="a")
+    grp_path = f"{node_name}/userData"
+    grp = zf.require_group(grp_path)
+    if key in grp:
+        del grp[key]
+    raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    grp.create_array(key, data=np.array(raw, dtype=f"S{len(raw)}"))
 
 
 @app.post("/classifier/save")

--- a/patch_classification/H-optimus-0/hoptimus_classification_tasknode.py
+++ b/patch_classification/H-optimus-0/hoptimus_classification_tasknode.py
@@ -1609,9 +1609,9 @@ def run_classification(args) -> Dict[str, Any]:
         classes_grp = grp_cls.require_group('classes')
         classes_grp.create_array('index', data=np.arange(len(final_class_names), dtype=np.int32))
         class_names_ascii = [n.encode('utf-8') for n in final_class_names]
-        classes_grp.create_array('name', shape=(len(class_names_ascii),), dtype='S256', data=class_names_ascii)
+        classes_grp.create_array('name', data=np.array(class_names_ascii, dtype='S256'))
         colors_ascii = [c.encode('utf-8') for c in final_class_colors]
-        classes_grp.create_array('color', shape=(len(colors_ascii),), dtype='S256', data=colors_ascii)
+        classes_grp.create_array('color', data=np.array(colors_ascii, dtype='S256'))
 
         # Update all annotation colors to match new class colors
         # This ensures that when user changes a class color and clicks Update,
@@ -1641,7 +1641,7 @@ def run_classification(args) -> Dict[str, Any]:
                                 updated_count += 1
                     if updated_count > 0:
                         del zf['User-Annotations/patch']
-                        zf['User-Annotations'].create_array('patch', data=patch_arr, dtype=patch_arr.dtype)
+                        zf['User-Annotations'].create_array('patch', data=patch_arr)
                         print(f"Updated {updated_count} patch annotation colors to match new class colors")
         except Exception as e:
             # If update fails, log but don't fail the workflow.

--- a/patch_classification/H-optimus-0/hoptimus_classification_tasknode.py
+++ b/patch_classification/H-optimus-0/hoptimus_classification_tasknode.py
@@ -1288,7 +1288,7 @@ def run_classification(args) -> Dict[str, Any]:
         zarr_path = ZARR_PATH
 
         # Open Zarr store once for all operations
-        zf = zarr.open_group(zarr_path, 'a')
+        zf = zarr.open_group(zarr_path, mode='a')
         # A) check annotation
         annotations_data = None
         use_supervised = False
@@ -1978,7 +1978,7 @@ def read_node(data: Dict[str, Any]):
             tissue_classes=["Negative control", "Tumor"]
         )
 
-    zf = zarr.open_group(ZARR_PATH, "r")
+    zf = zarr.open_group(ZARR_PATH, mode="r")
     user_data_path = f"{ZARR_GROUP}/userData"
     if user_data_path in zf:
         for k in zf[user_data_path].keys():

--- a/patch_classification/H-optimus-0/hoptimus_embedding_taskNode.py
+++ b/patch_classification/H-optimus-0/hoptimus_embedding_taskNode.py
@@ -154,7 +154,7 @@ def print_zarr_structure(file_path):
                 shape = getattr(val, 'shape', None)
                 dtype = getattr(val, 'dtype', None)
                 print(f"{name} (Dataset), shape: {shape}, dtype: {dtype}")
-    zf = zarr.open_group(file_path, "r")
+    zf = zarr.open_group(file_path, mode="r")
     _visit(zf)
 
 def load_model_at_init():
@@ -206,7 +206,7 @@ def run_patch_classification(args):
         coordinates = None
         
         if os.path.exists(ZARR_PATH):
-            zf = zarr.open_group(ZARR_PATH, 'r')
+            zf = zarr.open_group(ZARR_PATH, mode='r')
             if ZARR_GROUP in zf:
                     try:
                         # Load coordinates and embeddings
@@ -306,7 +306,7 @@ def run_patch_classification(args):
         
         # Step 3: Save to Zarr store (only if we generated new embeddings)
         if not ALREADY_HAVE_EMBEDDINGS and embeddings is not None and coordinates is not None:
-            zf = zarr.open_group(ZARR_PATH, "a")
+            zf = zarr.open_group(ZARR_PATH, mode="a")
             if ZARR_GROUP in zf:
                 del zf[ZARR_GROUP]
             node_grp = zf.create_group(ZARR_GROUP)
@@ -612,7 +612,7 @@ def _load_parameters_from_zarr(zarr_path: str, zarr_group: str):
     global ARGS
     
     try:
-        zf = zarr.open_group(zarr_path, "r")
+        zf = zarr.open_group(zarr_path, mode="r")
         user_data_path = f"{zarr_group}/userData"
         if user_data_path not in zf:
             print(f"[{NODE_NAME}] No userData found in {zarr_group}")
@@ -733,7 +733,7 @@ def execute_node():
     
     # Store the result to 'output'
     if ZARR_PATH and os.path.exists(ZARR_PATH):
-        zf = zarr.open_group(ZARR_PATH, "a")
+        zf = zarr.open_group(ZARR_PATH, mode="a")
         node_out_path = f"{ZARR_GROUP}/output"
         if node_out_path in zf:
             del zf[node_out_path]

--- a/patch_classification/H-optimus-0/hoptimus_embedding_taskNode.py
+++ b/patch_classification/H-optimus-0/hoptimus_embedding_taskNode.py
@@ -147,7 +147,7 @@ def print_zarr_structure(file_path):
     def _visit(group, prefix=""):
         for key, val in group.items():
             name = f"{prefix}/{key}" if prefix else key
-            if isinstance(val, zarr.hierarchy.Group):
+            if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")
                 _visit(val, name)
             else:
@@ -310,8 +310,8 @@ def run_patch_classification(args):
             if ZARR_GROUP in zf:
                 del zf[ZARR_GROUP]
             node_grp = zf.create_group(ZARR_GROUP)
-            node_grp.create_dataset('embeddings', data=embeddings)
-            node_grp.create_dataset('coordinates', data=coordinates)
+            node_grp.create_array('embeddings', data=embeddings)
+            node_grp.create_array('coordinates', data=coordinates)
             # Run metadata as a sub-group with attrs (matches the
             # Cell-Segmentation/metadata pattern; replaces the historical
             # JSON-bytes 'output' + 'metadata' blobs).
@@ -739,7 +739,7 @@ def execute_node():
             del zf[node_out_path]
         out_str = json.dumps(out_val, ensure_ascii=False)
         out_bytes = out_str.encode("utf-8")
-        zf.create_dataset(node_out_path, shape=(), dtype=f'S{len(out_bytes)}', data=out_bytes)
+        zf.create_array(node_out_path, data=np.array(out_bytes, dtype=f'S{len(out_bytes)}'))
         time.sleep(1)
     
     return {"status": "ok", "output": out_val}

--- a/patch_classification/H-optimus-0/hoptimus_embedding_taskNode.py
+++ b/patch_classification/H-optimus-0/hoptimus_embedding_taskNode.py
@@ -12,6 +12,12 @@ import time
 import json
 import zarr
 import uvicorn
+
+# Silence zarr v3 "unstable data type" warnings (structured arrays + fixed-length
+# string/bytes dtypes used by our schema). No cross-library portability needed.
+import warnings
+from zarr.errors import UnstableSpecificationWarning
+warnings.filterwarnings("ignore", category=UnstableSpecificationWarning)
 import requests
 import platform
 import numpy as np
@@ -145,7 +151,7 @@ def update_progress(value):
 def print_zarr_structure(file_path):
     """Helper to print Zarr structure"""
     def _visit(group, prefix=""):
-        for key, val in group.items():
+        for key, val in group.members():
             name = f"{prefix}/{key}" if prefix else key
             if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")

--- a/patch_classification/MUSK/main.py
+++ b/patch_classification/MUSK/main.py
@@ -78,7 +78,7 @@ def run_patch_classification_one(musk, wsi_path, output_dir, patch_size=224, lev
     # Step 1: Check if zarr exists and patch_size matches => skip (same as taskNode)
     if os.path.exists(zarr_path):
         try:
-            zf = zarr.open_group(zarr_path, "r")
+            zf = zarr.open_group(zarr_path, mode="r")
             if zarr_group in zf:
                 coordinates = zf[f"{zarr_group}/coordinates"][()]
                 embeddings = zf[f"{zarr_group}/embeddings"][()]
@@ -123,7 +123,7 @@ def run_patch_classification_one(musk, wsi_path, output_dir, patch_size=224, lev
 
     # Same canonical layout as musk_embedding_taskNode writes:
     #   <zarr_group>/embeddings, /coordinates, /metadata (group + attrs).
-    zf = zarr.open_group(zarr_path, "w")
+    zf = zarr.open_group(zarr_path, mode="w")
     if zarr_group in zf:
         del zf[zarr_group]
     node_grp = zf.create_group(zarr_group)

--- a/patch_classification/MUSK/main.py
+++ b/patch_classification/MUSK/main.py
@@ -127,8 +127,8 @@ def run_patch_classification_one(musk, wsi_path, output_dir, patch_size=224, lev
     if zarr_group in zf:
         del zf[zarr_group]
     node_grp = zf.create_group(zarr_group)
-    node_grp.create_dataset("embeddings", data=embeddings)
-    node_grp.create_dataset("coordinates", data=coordinates)
+    node_grp.create_array("embeddings", data=embeddings)
+    node_grp.create_array("coordinates", data=coordinates)
     meta_grp = node_grp.require_group("metadata")
     meta_grp.attrs.update({"patch_size": int(patch_size), "level": int(level)})
 

--- a/patch_classification/MUSK/model/model.safetensors
+++ b/patch_classification/MUSK/model/model.safetensors
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83d9f2429ec3f04fc3bdc4bc6d8e6c78035ea196fdce9fe05d76ea0e8cad0375
+size 1350493986

--- a/patch_classification/MUSK/musk_classification_tasknode.py
+++ b/patch_classification/MUSK/musk_classification_tasknode.py
@@ -191,7 +191,7 @@ def print_zarr_structure(file_path):
     def _visit(group, prefix=""):
         for key, val in group.items():
             name = f"{prefix}/{key}" if prefix else key
-            if isinstance(val, zarr.hierarchy.Group):
+            if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")
                 _visit(val, name)
             else:
@@ -1588,24 +1588,24 @@ def run_classification(args) -> Dict[str, Any]:
             del zf[ZARR_GROUP]
         grp_cls = zf.create_group(ZARR_GROUP)
 
-        grp_cls.create_dataset('class_indices', data=predictions.astype(np.int32))
+        grp_cls.create_array('class_indices', data=predictions.astype(np.int32))
 
         # Persist per-patch class probabilities so downstream (patch review /
         # active learning) can do threshold + uncertainty filtering.
         # prediction_probs is (n_patches, n_classes); None in zero-shot mode.
         if prediction_probs is not None:
-            grp_cls.create_dataset(
+            grp_cls.create_array(
                 'probabilities',
                 data=np.asarray(prediction_probs, dtype=np.float32),
             )
 
         # Per-class taxonomy under classes/{index, name, color}.
         classes_grp = grp_cls.require_group('classes')
-        classes_grp.create_dataset('index', data=np.arange(len(final_class_names), dtype=np.int32))
+        classes_grp.create_array('index', data=np.arange(len(final_class_names), dtype=np.int32))
         class_names_ascii = [n.encode('utf-8') for n in final_class_names]
-        classes_grp.create_dataset('name', shape=(len(class_names_ascii),), dtype='S256', data=class_names_ascii)
+        classes_grp.create_array('name', shape=(len(class_names_ascii),), dtype='S256', data=class_names_ascii)
         colors_ascii = [c.encode('utf-8') for c in final_class_colors]
-        classes_grp.create_dataset('color', shape=(len(colors_ascii),), dtype='S256', data=colors_ascii)
+        classes_grp.create_array('color', shape=(len(colors_ascii),), dtype='S256', data=colors_ascii)
 
         # Update all annotation colors to match new class colors
         # This ensures that when user changes a class color and clicks Update,
@@ -1635,7 +1635,7 @@ def run_classification(args) -> Dict[str, Any]:
                                 updated_count += 1
                     if updated_count > 0:
                         del zf['User-Annotations/patch']
-                        zf['User-Annotations'].create_dataset('patch', data=patch_arr, dtype=patch_arr.dtype)
+                        zf['User-Annotations'].create_array('patch', data=patch_arr, dtype=patch_arr.dtype)
                         print(f"Updated {updated_count} patch annotation colors to match new class colors")
         except Exception as e:
             # If update fails, log but don't fail the workflow.
@@ -2018,13 +2018,13 @@ def read_node(data: Dict[str, Any]):
 
 def _user_data_write_json(zarr_path: str, node_name: str, key: str, payload: Any) -> None:
     """Persist one key under {node_name}/userData (JSON bytes), matching tasks_service /read layout."""
-    with zarr.open_group(zarr_path, mode="a") as zf:
-        grp_path = f"{node_name}/userData"
-        grp = zf.require_group(grp_path)
-        if key in grp:
-            del grp[key]
-        raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-        grp.create_dataset(key, shape=(), dtype=f"S{len(raw)}", data=raw)
+    zf = zarr.open_group(zarr_path, mode="a")
+    grp_path = f"{node_name}/userData"
+    grp = zf.require_group(grp_path)
+    if key in grp:
+        del grp[key]
+    raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    grp.create_array(key, data=np.array(raw, dtype=f"S{len(raw)}"))
 
 
 @app.post("/classifier/save")

--- a/patch_classification/MUSK/musk_classification_tasknode.py
+++ b/patch_classification/MUSK/musk_classification_tasknode.py
@@ -1603,9 +1603,9 @@ def run_classification(args) -> Dict[str, Any]:
         classes_grp = grp_cls.require_group('classes')
         classes_grp.create_array('index', data=np.arange(len(final_class_names), dtype=np.int32))
         class_names_ascii = [n.encode('utf-8') for n in final_class_names]
-        classes_grp.create_array('name', shape=(len(class_names_ascii),), dtype='S256', data=class_names_ascii)
+        classes_grp.create_array('name', data=np.array(class_names_ascii, dtype='S256'))
         colors_ascii = [c.encode('utf-8') for c in final_class_colors]
-        classes_grp.create_array('color', shape=(len(colors_ascii),), dtype='S256', data=colors_ascii)
+        classes_grp.create_array('color', data=np.array(colors_ascii, dtype='S256'))
 
         # Update all annotation colors to match new class colors
         # This ensures that when user changes a class color and clicks Update,
@@ -1635,7 +1635,7 @@ def run_classification(args) -> Dict[str, Any]:
                                 updated_count += 1
                     if updated_count > 0:
                         del zf['User-Annotations/patch']
-                        zf['User-Annotations'].create_array('patch', data=patch_arr, dtype=patch_arr.dtype)
+                        zf['User-Annotations'].create_array('patch', data=patch_arr)
                         print(f"Updated {updated_count} patch annotation colors to match new class colors")
         except Exception as e:
             # If update fails, log but don't fail the workflow.

--- a/patch_classification/MUSK/musk_classification_tasknode.py
+++ b/patch_classification/MUSK/musk_classification_tasknode.py
@@ -27,6 +27,12 @@ import time
 import json
 import zarr
 import uvicorn
+
+# Silence zarr v3 "unstable data type" warnings (structured arrays + fixed-length
+# string/bytes dtypes used by our schema). No cross-library portability needed.
+import warnings
+from zarr.errors import UnstableSpecificationWarning
+warnings.filterwarnings("ignore", category=UnstableSpecificationWarning)
 import requests
 import numpy as np
 import pandas as pd
@@ -189,7 +195,7 @@ def _normalize_class_operations(raw_ops):
 def print_zarr_structure(file_path):
     """print Zarr store"""
     def _visit(group, prefix=""):
-        for key, val in group.items():
+        for key, val in group.members():
             name = f"{prefix}/{key}" if prefix else key
             if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")

--- a/patch_classification/MUSK/musk_classification_tasknode.py
+++ b/patch_classification/MUSK/musk_classification_tasknode.py
@@ -1282,7 +1282,7 @@ def run_classification(args) -> Dict[str, Any]:
         zarr_path = ZARR_PATH
 
         # Open Zarr store once for all operations
-        zf = zarr.open_group(zarr_path, 'a')
+        zf = zarr.open_group(zarr_path, mode='a')
         # A) check annotation
         annotations_data = None
         use_supervised = False
@@ -1972,7 +1972,7 @@ def read_node(data: Dict[str, Any]):
             tissue_classes=["Negative control", "Tumor"]
         )
 
-    zf = zarr.open_group(ZARR_PATH, "r")
+    zf = zarr.open_group(ZARR_PATH, mode="r")
     user_data_path = f"{ZARR_GROUP}/userData"
     if user_data_path in zf:
         for k in zf[user_data_path].keys():

--- a/patch_classification/MUSK/musk_embedding_taskNode.py
+++ b/patch_classification/MUSK/musk_embedding_taskNode.py
@@ -147,7 +147,7 @@ def print_zarr_structure(file_path):
     def _visit(group, prefix=""):
         for key, val in group.items():
             name = f"{prefix}/{key}" if prefix else key
-            if isinstance(val, zarr.hierarchy.Group):
+            if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")
                 _visit(val, name)
             else:
@@ -332,8 +332,8 @@ def run_patch_classification(args):
             if ZARR_GROUP in zf:
                 del zf[ZARR_GROUP]
             node_grp = zf.create_group(ZARR_GROUP)
-            node_grp.create_dataset('embeddings', data=embeddings)
-            node_grp.create_dataset('coordinates', data=coordinates)
+            node_grp.create_array('embeddings', data=embeddings)
+            node_grp.create_array('coordinates', data=coordinates)
             # Run metadata as a sub-group with attrs (matches the
             # Cell-Segmentation/metadata pattern; replaces the historical
             # JSON-bytes 'output' + 'metadata' blobs).
@@ -761,7 +761,7 @@ def execute_node():
             del zf[node_out_path]
         out_str = json.dumps(out_val, ensure_ascii=False)
         out_bytes = out_str.encode("utf-8")
-        zf.create_dataset(node_out_path, shape=(), dtype=f'S{len(out_bytes)}', data=out_bytes)
+        zf.create_array(node_out_path, data=np.array(out_bytes, dtype=f'S{len(out_bytes)}'))
         time.sleep(1)
     
     return {"status": "ok", "output": out_val}

--- a/patch_classification/MUSK/musk_embedding_taskNode.py
+++ b/patch_classification/MUSK/musk_embedding_taskNode.py
@@ -12,6 +12,12 @@ import time
 import json
 import zarr
 import uvicorn
+
+# Silence zarr v3 "unstable data type" warnings (structured arrays + fixed-length
+# string/bytes dtypes used by our schema). No cross-library portability needed.
+import warnings
+from zarr.errors import UnstableSpecificationWarning
+warnings.filterwarnings("ignore", category=UnstableSpecificationWarning)
 import requests
 import platform
 import numpy as np
@@ -145,7 +151,7 @@ def update_progress(value):
 def print_zarr_structure(file_path):
     """Helper to print Zarr structure"""
     def _visit(group, prefix=""):
-        for key, val in group.items():
+        for key, val in group.members():
             name = f"{prefix}/{key}" if prefix else key
             if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")

--- a/patch_classification/MUSK/musk_embedding_taskNode.py
+++ b/patch_classification/MUSK/musk_embedding_taskNode.py
@@ -154,7 +154,7 @@ def print_zarr_structure(file_path):
                 shape = getattr(val, 'shape', None)
                 dtype = getattr(val, 'dtype', None)
                 print(f"{name} (Dataset), shape: {shape}, dtype: {dtype}")
-    zf = zarr.open_group(file_path, "r")
+    zf = zarr.open_group(file_path, mode="r")
     _visit(zf)
 
 def load_model_at_init():
@@ -228,7 +228,7 @@ def run_patch_classification(args):
         coordinates = None
         
         if os.path.exists(ZARR_PATH):
-            zf = zarr.open_group(ZARR_PATH, 'r')
+            zf = zarr.open_group(ZARR_PATH, mode='r')
             if ZARR_GROUP in zf:
                     try:
                         # Load coordinates and embeddings
@@ -328,7 +328,7 @@ def run_patch_classification(args):
         
         # Step 3: Save to Zarr store (only if we generated new embeddings)
         if not ALREADY_HAVE_EMBEDDINGS and embeddings is not None and coordinates is not None:
-            zf = zarr.open_group(ZARR_PATH, "a")
+            zf = zarr.open_group(ZARR_PATH, mode="a")
             if ZARR_GROUP in zf:
                 del zf[ZARR_GROUP]
             node_grp = zf.create_group(ZARR_GROUP)
@@ -634,7 +634,7 @@ def _load_parameters_from_zarr(zarr_path: str, zarr_group: str):
     global ARGS
     
     try:
-        zf = zarr.open_group(zarr_path, "r")
+        zf = zarr.open_group(zarr_path, mode="r")
         user_data_path = f"{zarr_group}/userData"
         if user_data_path not in zf:
             print(f"[{NODE_NAME}] No userData found in {zarr_group}")
@@ -755,7 +755,7 @@ def execute_node():
     
     # Store the result to 'output'
     if ZARR_PATH and os.path.exists(ZARR_PATH):
-        zf = zarr.open_group(ZARR_PATH, "a")
+        zf = zarr.open_group(ZARR_PATH, mode="a")
         node_out_path = f"{ZARR_GROUP}/output"
         if node_out_path in zf:
             del zf[node_out_path]

--- a/patch_classification/Virchow/virchow_classification_tasknode.py
+++ b/patch_classification/Virchow/virchow_classification_tasknode.py
@@ -27,6 +27,12 @@ import time
 import json
 import zarr
 import uvicorn
+
+# Silence zarr v3 "unstable data type" warnings (structured arrays + fixed-length
+# string/bytes dtypes used by our schema). No cross-library portability needed.
+import warnings
+from zarr.errors import UnstableSpecificationWarning
+warnings.filterwarnings("ignore", category=UnstableSpecificationWarning)
 import requests
 import numpy as np
 import pandas as pd
@@ -196,7 +202,7 @@ def _normalize_class_operations(raw_ops):
 def print_zarr_structure(file_path):
     """print Zarr store"""
     def _visit(group, prefix=""):
-        for key, val in group.items():
+        for key, val in group.members():
             name = f"{prefix}/{key}" if prefix else key
             if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")

--- a/patch_classification/Virchow/virchow_classification_tasknode.py
+++ b/patch_classification/Virchow/virchow_classification_tasknode.py
@@ -198,7 +198,7 @@ def print_zarr_structure(file_path):
     def _visit(group, prefix=""):
         for key, val in group.items():
             name = f"{prefix}/{key}" if prefix else key
-            if isinstance(val, zarr.hierarchy.Group):
+            if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")
                 _visit(val, name)
             else:
@@ -1594,24 +1594,24 @@ def run_classification(args) -> Dict[str, Any]:
             del zf[ZARR_GROUP]
         grp_cls = zf.create_group(ZARR_GROUP)
 
-        grp_cls.create_dataset('class_indices', data=predictions.astype(np.int32))
+        grp_cls.create_array('class_indices', data=predictions.astype(np.int32))
 
         # Persist per-patch class probabilities so downstream (patch review /
         # active learning) can do threshold + uncertainty filtering.
         # prediction_probs is (n_patches, n_classes); None in zero-shot mode.
         if prediction_probs is not None:
-            grp_cls.create_dataset(
+            grp_cls.create_array(
                 'probabilities',
                 data=np.asarray(prediction_probs, dtype=np.float32),
             )
 
         # Per-class taxonomy under classes/{index, name, color}.
         classes_grp = grp_cls.require_group('classes')
-        classes_grp.create_dataset('index', data=np.arange(len(final_class_names), dtype=np.int32))
+        classes_grp.create_array('index', data=np.arange(len(final_class_names), dtype=np.int32))
         class_names_ascii = [n.encode('utf-8') for n in final_class_names]
-        classes_grp.create_dataset('name', shape=(len(class_names_ascii),), dtype='S256', data=class_names_ascii)
+        classes_grp.create_array('name', shape=(len(class_names_ascii),), dtype='S256', data=class_names_ascii)
         colors_ascii = [c.encode('utf-8') for c in final_class_colors]
-        classes_grp.create_dataset('color', shape=(len(colors_ascii),), dtype='S256', data=colors_ascii)
+        classes_grp.create_array('color', shape=(len(colors_ascii),), dtype='S256', data=colors_ascii)
 
         # Update all annotation colors to match new class colors
         # This ensures that when user changes a class color and clicks Update,
@@ -1641,7 +1641,7 @@ def run_classification(args) -> Dict[str, Any]:
                                 updated_count += 1
                     if updated_count > 0:
                         del zf['User-Annotations/patch']
-                        zf['User-Annotations'].create_dataset('patch', data=patch_arr, dtype=patch_arr.dtype)
+                        zf['User-Annotations'].create_array('patch', data=patch_arr, dtype=patch_arr.dtype)
                         print(f"Updated {updated_count} patch annotation colors to match new class colors")
         except Exception as e:
             # If update fails, log but don't fail the workflow.
@@ -2024,13 +2024,13 @@ def read_node(data: Dict[str, Any]):
 
 def _user_data_write_json(zarr_path: str, node_name: str, key: str, payload: Any) -> None:
     """Persist one key under {node_name}/userData (JSON bytes), matching tasks_service /read layout."""
-    with zarr.open_group(zarr_path, mode="a") as zf:
-        grp_path = f"{node_name}/userData"
-        grp = zf.require_group(grp_path)
-        if key in grp:
-            del grp[key]
-        raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-        grp.create_dataset(key, shape=(), dtype=f"S{len(raw)}", data=raw)
+    zf = zarr.open_group(zarr_path, mode="a")
+    grp_path = f"{node_name}/userData"
+    grp = zf.require_group(grp_path)
+    if key in grp:
+        del grp[key]
+    raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    grp.create_array(key, data=np.array(raw, dtype=f"S{len(raw)}"))
 
 
 @app.post("/classifier/save")

--- a/patch_classification/Virchow/virchow_classification_tasknode.py
+++ b/patch_classification/Virchow/virchow_classification_tasknode.py
@@ -1609,9 +1609,9 @@ def run_classification(args) -> Dict[str, Any]:
         classes_grp = grp_cls.require_group('classes')
         classes_grp.create_array('index', data=np.arange(len(final_class_names), dtype=np.int32))
         class_names_ascii = [n.encode('utf-8') for n in final_class_names]
-        classes_grp.create_array('name', shape=(len(class_names_ascii),), dtype='S256', data=class_names_ascii)
+        classes_grp.create_array('name', data=np.array(class_names_ascii, dtype='S256'))
         colors_ascii = [c.encode('utf-8') for c in final_class_colors]
-        classes_grp.create_array('color', shape=(len(colors_ascii),), dtype='S256', data=colors_ascii)
+        classes_grp.create_array('color', data=np.array(colors_ascii, dtype='S256'))
 
         # Update all annotation colors to match new class colors
         # This ensures that when user changes a class color and clicks Update,
@@ -1641,7 +1641,7 @@ def run_classification(args) -> Dict[str, Any]:
                                 updated_count += 1
                     if updated_count > 0:
                         del zf['User-Annotations/patch']
-                        zf['User-Annotations'].create_array('patch', data=patch_arr, dtype=patch_arr.dtype)
+                        zf['User-Annotations'].create_array('patch', data=patch_arr)
                         print(f"Updated {updated_count} patch annotation colors to match new class colors")
         except Exception as e:
             # If update fails, log but don't fail the workflow.

--- a/patch_classification/Virchow/virchow_classification_tasknode.py
+++ b/patch_classification/Virchow/virchow_classification_tasknode.py
@@ -1288,7 +1288,7 @@ def run_classification(args) -> Dict[str, Any]:
         zarr_path = ZARR_PATH
 
         # Open Zarr store once for all operations
-        zf = zarr.open_group(zarr_path, 'a')
+        zf = zarr.open_group(zarr_path, mode='a')
         # A) check annotation
         annotations_data = None
         use_supervised = False
@@ -1978,7 +1978,7 @@ def read_node(data: Dict[str, Any]):
             tissue_classes=["Negative control", "Tumor"]
         )
 
-    zf = zarr.open_group(ZARR_PATH, "r")
+    zf = zarr.open_group(ZARR_PATH, mode="r")
     user_data_path = f"{ZARR_GROUP}/userData"
     if user_data_path in zf:
         for k in zf[user_data_path].keys():

--- a/patch_classification/Virchow/virchow_embedding_taskNode.py
+++ b/patch_classification/Virchow/virchow_embedding_taskNode.py
@@ -147,7 +147,7 @@ def print_zarr_structure(file_path):
     def _visit(group, prefix=""):
         for key, val in group.items():
             name = f"{prefix}/{key}" if prefix else key
-            if isinstance(val, zarr.hierarchy.Group):
+            if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")
                 _visit(val, name)
             else:
@@ -309,8 +309,8 @@ def run_patch_classification(args):
             if ZARR_GROUP in zf:
                 del zf[ZARR_GROUP]
             node_grp = zf.create_group(ZARR_GROUP)
-            node_grp.create_dataset('embeddings', data=embeddings)
-            node_grp.create_dataset('coordinates', data=coordinates)
+            node_grp.create_array('embeddings', data=embeddings)
+            node_grp.create_array('coordinates', data=coordinates)
             # Run metadata as a sub-group with attrs (matches the
             # Cell-Segmentation/metadata pattern; replaces the historical
             # JSON-bytes 'output' + 'metadata' blobs).
@@ -738,7 +738,7 @@ def execute_node():
             del zf[node_out_path]
         out_str = json.dumps(out_val, ensure_ascii=False)
         out_bytes = out_str.encode("utf-8")
-        zf.create_dataset(node_out_path, shape=(), dtype=f'S{len(out_bytes)}', data=out_bytes)
+        zf.create_array(node_out_path, data=np.array(out_bytes, dtype=f'S{len(out_bytes)}'))
         time.sleep(1)
     
     return {"status": "ok", "output": out_val}

--- a/patch_classification/Virchow/virchow_embedding_taskNode.py
+++ b/patch_classification/Virchow/virchow_embedding_taskNode.py
@@ -12,6 +12,12 @@ import time
 import json
 import zarr
 import uvicorn
+
+# Silence zarr v3 "unstable data type" warnings (structured arrays + fixed-length
+# string/bytes dtypes used by our schema). No cross-library portability needed.
+import warnings
+from zarr.errors import UnstableSpecificationWarning
+warnings.filterwarnings("ignore", category=UnstableSpecificationWarning)
 import requests
 import platform
 import numpy as np
@@ -145,7 +151,7 @@ def update_progress(value):
 def print_zarr_structure(file_path):
     """Helper to print Zarr structure"""
     def _visit(group, prefix=""):
-        for key, val in group.items():
+        for key, val in group.members():
             name = f"{prefix}/{key}" if prefix else key
             if isinstance(val, zarr.Group):
                 print(f"{name} (Group)")

--- a/patch_classification/Virchow/virchow_embedding_taskNode.py
+++ b/patch_classification/Virchow/virchow_embedding_taskNode.py
@@ -154,7 +154,7 @@ def print_zarr_structure(file_path):
                 shape = getattr(val, 'shape', None)
                 dtype = getattr(val, 'dtype', None)
                 print(f"{name} (Dataset), shape: {shape}, dtype: {dtype}")
-    zf = zarr.open_group(file_path, "r")
+    zf = zarr.open_group(file_path, mode="r")
     _visit(zf)
 
 def load_model_at_init():
@@ -205,7 +205,7 @@ def run_patch_classification(args):
         coordinates = None
         
         if os.path.exists(ZARR_PATH):
-            zf = zarr.open_group(ZARR_PATH, 'r')
+            zf = zarr.open_group(ZARR_PATH, mode='r')
             if ZARR_GROUP in zf:
                     try:
                         # Load coordinates and embeddings
@@ -305,7 +305,7 @@ def run_patch_classification(args):
         
         # Step 3: Save to Zarr store (only if we generated new embeddings)
         if not ALREADY_HAVE_EMBEDDINGS and embeddings is not None and coordinates is not None:
-            zf = zarr.open_group(ZARR_PATH, "a")
+            zf = zarr.open_group(ZARR_PATH, mode="a")
             if ZARR_GROUP in zf:
                 del zf[ZARR_GROUP]
             node_grp = zf.create_group(ZARR_GROUP)
@@ -611,7 +611,7 @@ def _load_parameters_from_zarr(zarr_path: str, zarr_group: str):
     global ARGS
     
     try:
-        zf = zarr.open_group(zarr_path, "r")
+        zf = zarr.open_group(zarr_path, mode="r")
         user_data_path = f"{zarr_group}/userData"
         if user_data_path not in zf:
             print(f"[{NODE_NAME}] No userData found in {zarr_group}")
@@ -732,7 +732,7 @@ def execute_node():
     
     # Store the result to 'output'
     if ZARR_PATH and os.path.exists(ZARR_PATH):
-        zf = zarr.open_group(ZARR_PATH, "a")
+        zf = zarr.open_group(ZARR_PATH, mode="a")
         node_out_path = f"{ZARR_GROUP}/output"
         if node_out_path in zf:
             del zf[node_out_path]

--- a/scripts/migrate_classification_groups.py
+++ b/scripts/migrate_classification_groups.py
@@ -83,12 +83,26 @@ def _rename_group_fs(zarr_path: Path) -> bool:
     return True
 
 
+def _zarr_copy(src, dst_parent, name):
+    """zarr v3 replacement for the removed ``zarr.copy``: deep-copy an array or
+    group ``src`` into ``dst_parent`` under ``name``, preserving dtype/attrs."""
+    if isinstance(src, zarr.Group):
+        dst = dst_parent.require_group(name)
+        dst.attrs.update(dict(src.attrs))
+        for key in src.keys():
+            _zarr_copy(src[key], dst, key)
+        return dst
+    dst = dst_parent.create_array(name, data=src[...], chunks=src.chunks, overwrite=True)
+    dst.attrs.update(dict(src.attrs))
+    return dst
+
+
 def _rename_flat_datasets(grp) -> List[str]:
     """In-place rename for flat per-cell datasets."""
     renamed: List[str] = []
     for old_key, new_key in FLAT_DATASET_RENAMES.items():
         if old_key in grp and new_key not in grp:
-            zarr.copy(grp[old_key], grp, name=new_key)
+            _zarr_copy(grp[old_key], grp, new_key)
             del grp[old_key]
             renamed.append(f"{old_key} → {new_key}")
     return renamed
@@ -113,7 +127,7 @@ def _move_class_datasets_to_subgroup(grp) -> List[str]:
             continue
         if new_key in classes_grp:
             del classes_grp[new_key]
-        zarr.copy(grp[old_key], classes_grp, name=new_key)
+        _zarr_copy(grp[old_key], classes_grp, new_key)
         del grp[old_key]
         moved.append(f"{old_key} → {CLASSES_SUBGROUP}/{new_key}")
 
@@ -128,7 +142,7 @@ def _move_class_datasets_to_subgroup(grp) -> List[str]:
             except Exception:
                 pass
     if m is not None and "index" not in classes_grp:
-        classes_grp.create_dataset("index", data=np.arange(m, dtype=np.int32))
+        classes_grp.create_array("index", data=np.arange(m, dtype=np.int32))
         moved.append(f"classes/index materialised [0..{m - 1}]")
 
     return moved
@@ -140,7 +154,7 @@ def _promote_output_to_metadata(grp) -> bool:
         return False
     node = grp[OUTPUT_DATASET]
     # If it's already a group, nothing to do.
-    if isinstance(node, zarr.hierarchy.Group):
+    if isinstance(node, zarr.Group):
         return False
     raw = bytes(node[()])
     payload = {}
@@ -195,7 +209,7 @@ def migrate_one(zarr_path: Path, dry_run: bool) -> Tuple[Path, str, List[str]]:
             for old_key, new_key in CLASS_DATASET_MOVES.items():
                 if old_key in grp:
                     actions.append(f"would move {old_key} → {CLASSES_SUBGROUP}/{new_key}")
-            if OUTPUT_DATASET in grp and not isinstance(grp[OUTPUT_DATASET], zarr.hierarchy.Group):
+            if OUTPUT_DATASET in grp and not isinstance(grp[OUTPUT_DATASET], zarr.Group):
                 actions.append(f"would promote {OUTPUT_DATASET} (bytes) → metadata group + attrs")
             return zarr_path, "migrated" if actions else "skipped", actions
 
@@ -210,7 +224,7 @@ def migrate_one(zarr_path: Path, dry_run: bool) -> Tuple[Path, str, List[str]]:
             actions.append(f"promoted {OUTPUT_DATASET} → metadata group + attrs")
         # Drop the older sibling "output" JSON-bytes blob if present — newer
         # NuClass writes everything into metadata attrs, so it is dead data.
-        if LEGACY_OUTPUT_DATASET in grp and not isinstance(grp[LEGACY_OUTPUT_DATASET], zarr.hierarchy.Group):
+        if LEGACY_OUTPUT_DATASET in grp and not isinstance(grp[LEGACY_OUTPUT_DATASET], zarr.Group):
             del grp[LEGACY_OUTPUT_DATASET]
             actions.append(f"dropped legacy {LEGACY_OUTPUT_DATASET} bytes blob")
 

--- a/scripts/migrate_patch_groups.py
+++ b/scripts/migrate_patch_groups.py
@@ -90,7 +90,21 @@ def find_zarr_stores(root: Path) -> List[Path]:
 
 def _is_array(node) -> bool:
     """True iff node is a zarr Array (not a Group)."""
-    return not isinstance(node, zarr.hierarchy.Group)
+    return not isinstance(node, zarr.Group)
+
+
+def _zarr_copy(src, dst_parent, name):
+    """zarr v3 replacement for the removed ``zarr.copy``: deep-copy an array or
+    group ``src`` into ``dst_parent`` under ``name``, preserving dtype/attrs."""
+    if isinstance(src, zarr.Group):
+        dst = dst_parent.require_group(name)
+        dst.attrs.update(dict(src.attrs))
+        for key in src.keys():
+            _zarr_copy(src[key], dst, key)
+        return dst
+    dst = dst_parent.create_array(name, data=src[...], chunks=src.chunks, overwrite=True)
+    dst.attrs.update(dict(src.attrs))
+    return dst
 
 
 def _read_bytes_blob(node) -> bytes:
@@ -131,7 +145,7 @@ def _split_old_node(zf, dry_run: bool) -> List[str]:
                 if old_key in old:
                     if new_key in seg:
                         del seg[new_key]
-                    zarr.copy(old[old_key], seg, name=new_key)
+                    _zarr_copy(old[old_key], seg, new_key)
                     actions.append(f"{OLD_GROUP}/{old_key} → {PATCH_SEG}/{new_key}")
             # Promote legacy metadata bytes blob if it carries patch-embedding params.
             if LEGACY_METADATA_DATASET in old and _is_array(old[LEGACY_METADATA_DATASET]):
@@ -156,7 +170,7 @@ def _split_old_node(zf, dry_run: bool) -> List[str]:
             if USER_DATA_DATASET in old:
                 if USER_DATA_DATASET in seg:
                     del seg[USER_DATA_DATASET]
-                zarr.copy(old[USER_DATA_DATASET], seg, name=USER_DATA_DATASET)
+                _zarr_copy(old[USER_DATA_DATASET], seg, USER_DATA_DATASET)
                 actions.append(f"{OLD_GROUP}/{USER_DATA_DATASET} → {PATCH_SEG}/{USER_DATA_DATASET}")
 
     elif dry_run and (LEGACY_METADATA_DATASET in old and _is_array(old[LEGACY_METADATA_DATASET])):
@@ -172,7 +186,7 @@ def _split_old_node(zf, dry_run: bool) -> List[str]:
                 if old_key in old:
                     if new_key in cls:
                         del cls[new_key]
-                    zarr.copy(old[old_key], cls, name=new_key)
+                    _zarr_copy(old[old_key], cls, new_key)
                     actions.append(f"{OLD_GROUP}/{old_key} → {PATCH_CLS}/{new_key}")
 
             # Per-class taxonomy into classes/ subgroup.
@@ -183,7 +197,7 @@ def _split_old_node(zf, dry_run: bool) -> List[str]:
                     if old_key in old:
                         if new_key in classes_grp:
                             del classes_grp[new_key]
-                        zarr.copy(old[old_key], classes_grp, name=new_key)
+                        _zarr_copy(old[old_key], classes_grp, new_key)
                         actions.append(
                             f"{OLD_GROUP}/{old_key} → {PATCH_CLS}/{CLS_CLASSES_SUBGROUP}/{new_key}"
                         )
@@ -197,7 +211,7 @@ def _split_old_node(zf, dry_run: bool) -> List[str]:
                         except Exception:
                             pass
                 if m is not None and "index" not in classes_grp:
-                    classes_grp.create_dataset("index", data=np.arange(m, dtype=np.int32))
+                    classes_grp.create_array("index", data=np.arange(m, dtype=np.int32))
                     actions.append(f"{PATCH_CLS}/{CLS_CLASSES_SUBGROUP}/index materialised [0..{m - 1}]")
 
             # Promote classification metadata bytes blob if not already used by embedding side.

--- a/scripts/migrate_segmentation_groups.py
+++ b/scripts/migrate_segmentation_groups.py
@@ -79,12 +79,26 @@ def _rename_group_fs(zarr_path: Path) -> bool:
     return True
 
 
+def _zarr_copy(src, dst_parent, name):
+    """zarr v3 replacement for the removed ``zarr.copy``: deep-copy an array or
+    group ``src`` into ``dst_parent`` under ``name``, preserving dtype/attrs."""
+    if isinstance(src, zarr.Group):
+        dst = dst_parent.require_group(name)
+        dst.attrs.update(dict(src.attrs))
+        for key in src.keys():
+            _zarr_copy(src[key], dst, key)
+        return dst
+    dst = dst_parent.create_array(name, data=src[...], chunks=src.chunks, overwrite=True)
+    dst.attrs.update(dict(src.attrs))
+    return dst
+
+
 def _rename_datasets(seg_grp) -> List[str]:
     """In-place rename embedding→embeddings, probability→probabilities."""
     renamed = []
     for old_key, new_key in DATASET_RENAMES.items():
         if old_key in seg_grp and new_key not in seg_grp:
-            zarr.copy(seg_grp[old_key], seg_grp, name=new_key)
+            _zarr_copy(seg_grp[old_key], seg_grp, new_key)
             del seg_grp[old_key]
             renamed.append(f"{old_key} → {new_key}")
     return renamed

--- a/scripts/migrate_user_annotations.py
+++ b/scripts/migrate_user_annotations.py
@@ -329,7 +329,7 @@ def migrate_one(zarr_path: Path, dry_run: bool) -> Tuple[Path, str, List[str]]:
                         n_cells = (max(ids) + 1) if ids else 0
                     new_arr, syn_names, syn_colors = _cell_dict_to_array(
                         ann_dict, n_cells, cell_class_names, cell_class_colors)
-                    ua.create_dataset(NEW_CELL_DS, data=new_arr, dtype=new_arr.dtype)
+                    ua.create_array(NEW_CELL_DS, data=new_arr, overwrite=True)
                     del ua[OLD_CELL_DS]
                     # Feed synthesised taxonomy into the attrs-writing step below.
                     if not cell_class_names and syn_names:
@@ -344,7 +344,7 @@ def migrate_one(zarr_path: Path, dry_run: bool) -> Tuple[Path, str, List[str]]:
                         new_arr = _rename_fields_in_array(old_arr, CELL_FIELD_RENAMES)
                     else:
                         new_arr = old_arr
-                    ua.create_dataset(NEW_CELL_DS, data=new_arr, dtype=new_arr.dtype)
+                    ua.create_array(NEW_CELL_DS, data=new_arr, overwrite=True)
                     del ua[OLD_CELL_DS]
                     actions.append(f"renamed {OLD_CELL_DS} → {NEW_CELL_DS}")
 
@@ -409,7 +409,7 @@ def migrate_one(zarr_path: Path, dry_run: bool) -> Tuple[Path, str, List[str]]:
                     n_patches = (max(keys_as_int) + 1) if keys_as_int else 0
                 # 3) Materialise dense array.
                 patch_arr = _patch_dict_to_array(ann_dict, n_patches, list(patch_class_names))
-                ua.create_dataset(NEW_PATCH_DS, data=patch_arr, dtype=patch_arr.dtype)
+                ua.create_array(NEW_PATCH_DS, data=patch_arr, overwrite=True)
                 del ua[OLD_PATCH_DS]
                 actions.append(f"{OLD_PATCH_DS} JSON({len(ann_dict)}) → {NEW_PATCH_DS} dense({n_patches})")
 

--- a/scripts/rename_class_counts_to_cell.py
+++ b/scripts/rename_class_counts_to_cell.py
@@ -103,7 +103,8 @@ def migrate_store(store: Path, dry_run: bool) -> Tuple[str, str]:
     if dry_run:
         return ("migrated", f"would rename {OLD_NAME} -> {NEW_NAME} (dtype={dtype}, value={preview})")
 
-    ua.create_dataset(NEW_NAME, data=value, shape=shape, dtype=dtype, overwrite=True)
+    new_ds = ua.create_array(NEW_NAME, shape=shape, dtype=dtype, overwrite=True)
+    new_ds[...] = value
     del ua[OLD_NAME]
     return ("migrated", f"renamed {OLD_NAME} -> {NEW_NAME} (value={preview})")
 

--- a/task_specific/Ark_Plus/Ark_Plus_tasknode.py
+++ b/task_specific/Ark_Plus/Ark_Plus_tasknode.py
@@ -333,15 +333,15 @@ def _save_results_to_zarr(predictions, disease_list, image_name):
     """Save predictions to Zarr store"""
     global ZARR_PATH, ZARR_GROUP
     try:
-        zf = zarr.open_group(ZARR_PATH, "a")
+        zf = zarr.open_group(ZARR_PATH, mode="a")
         if ZARR_GROUP in zf:
             del zf[ZARR_GROUP]
         group = zf.create_group(ZARR_GROUP)
-        group.create_dataset("predictions", data=predictions.astype(np.float32))
+        group.create_array("predictions", data=predictions.astype(np.float32))
         img_bytes = image_name.encode('utf-8')
-        group.create_dataset("image_name", shape=(), dtype=f'S{len(img_bytes)}', data=img_bytes)
+        group.create_array("image_name", data=np.array(img_bytes, dtype=f'S{len(img_bytes)}'))
         dl = np.array(disease_list, dtype='S')
-        group.create_dataset("disease_list", data=dl)
+        group.create_array("disease_list", data=dl)
         print(f"[{NODE_NAME}] Results saved to Zarr: {ZARR_GROUP}")
     except Exception as e:
         print(f"[{NODE_NAME}] Error saving results to Zarr: {e}")
@@ -409,7 +409,7 @@ def _load_parameters_from_zarr(zarr_path: str, zarr_group: str):
     """Load user parameters from Zarr"""
     global ARGS
     try:
-        zf = zarr.open_group(zarr_path, "r")
+        zf = zarr.open_group(zarr_path, mode="r")
         user_data_path = f"{zarr_group}/userData"
         if user_data_path not in zf:
             print(f"[{NODE_NAME}] No userData found in {zarr_group}")
@@ -495,13 +495,13 @@ def execute_node():
     
     # Store the result to 'output'
     if ZARR_PATH and os.path.exists(ZARR_PATH):
-        zf = zarr.open_group(ZARR_PATH, "a")
+        zf = zarr.open_group(ZARR_PATH, mode="a")
         node_out_path = f"{ZARR_GROUP}/output"
         if node_out_path in zf:
             del zf[node_out_path]
         out_str = json.dumps(out_val, ensure_ascii=False)
         out_bytes = out_str.encode("utf-8")
-        zf.create_dataset(node_out_path, shape=(), dtype=f'S{len(out_bytes)}', data=out_bytes)
+        zf.create_array(node_out_path, data=np.array(out_bytes, dtype=f'S{len(out_bytes)}'))
         time.sleep(1)
     
     return {"status": "ok", "output": out_val}

--- a/task_specific/Cardiac_Multi_view_segmentation-master/cardiac_tasknode.py
+++ b/task_specific/Cardiac_Multi_view_segmentation-master/cardiac_tasknode.py
@@ -436,10 +436,9 @@ def save_segmentation_to_zarr(segmentation_data: np.ndarray, original_image: sit
             
             # Create segmentation dataset
             print(f"[Zarr] Creating dataset with shape {segmentation_data.shape}")
-            seg_dataset = voxel_group.create_dataset(
+            seg_dataset = voxel_group.create_array(
                 dataset_name,
                 data=segmentation_data,
-                chunks=True
             )
             print(f"[Zarr] Dataset created successfully")
             
@@ -851,7 +850,7 @@ def read_node(data: Dict[str, Any]):
     # Check if Zarr store exists and read user data from it
     if ZARR_PATH and os.path.exists(ZARR_PATH):
         try:
-            zf = zarr.open_group(ZARR_PATH, "r")
+            zf = zarr.open_group(ZARR_PATH, mode="r")
             user_data_path = f"{NODE_NAME}/userData"
             if user_data_path in zf:
                 print(f"[Read] Found userData in Zarr store")

--- a/tissue_segmentation/BiomedParse/biomed_tasknode.py
+++ b/tissue_segmentation/BiomedParse/biomed_tasknode.py
@@ -521,7 +521,7 @@ def read_node(data: Dict[str, Any]):
     user_data_dict = {}
 
     # 3) Open the Zarr store and read userData / dependency outputs
-    zf = zarr.open_group(ZARR_PATH, "r")
+    zf = zarr.open_group(ZARR_PATH, mode="r")
     # 3.1) Read this node's userData
     self_ud = f"{NODE_NAME}/userData"
     if self_ud in zf:
@@ -923,7 +923,7 @@ def execute_node(background_tasks: BackgroundTasks):
 
     # write result to /<NODE_NAME>/output in Zarr
     if ZARR_PATH and os.path.exists(ZARR_PATH):
-        zf = zarr.open_group(ZARR_PATH, "a")
+        zf = zarr.open_group(ZARR_PATH, mode="a")
         out_path = f"{NODE_NAME}/output"
         if out_path in zf:
             del zf[out_path]

--- a/tissue_segmentation/BiomedParse/biomed_tasknode.py
+++ b/tissue_segmentation/BiomedParse/biomed_tasknode.py
@@ -929,7 +929,7 @@ def execute_node(background_tasks: BackgroundTasks):
             del zf[out_path]
         out_str = json.dumps(result_value, ensure_ascii=False)
         out_bytes = out_str.encode("utf-8")
-        zf.create_dataset(out_path, shape=(), dtype=f'S{len(out_bytes)}', data=out_bytes)
+        zf.create_array(out_path, data=np.array(out_bytes, dtype=f'S{len(out_bytes)}'))
 
     return {"status":"ok","output":result_value}
 

--- a/tissue_segmentation/SAM/requirements.txt
+++ b/tissue_segmentation/SAM/requirements.txt
@@ -83,7 +83,7 @@ nest-asyncio==1.6.0
 networkx==3.4.2
 notebook==7.2.2
 notebook_shim==0.2.4
-numcodecs==0.15.1
+numcodecs
 numpy==2.2.3
 omegaconf==2.3.0
 opencv-python==4.11.0.86
@@ -155,7 +155,7 @@ websocket-client==1.8.0
 websockets==15.0
 wheel==0.45.1
 wrapt==1.17.2
-zarr==2.13.3
+zarr==3.1.5
 protobuf>=3.20.0,<4
 sse-starlette
 

--- a/tissue_segmentation/SAM/sam_task_node.py
+++ b/tissue_segmentation/SAM/sam_task_node.py
@@ -606,7 +606,7 @@ def execute_node(background_tasks: BackgroundTasks):
         if ds_name in parent:
             del parent[ds_name]
         out_str = json.dumps(result_value, ensure_ascii=False).encode("utf-8")
-        parent.create_dataset(ds_name, shape=(), dtype=f'S{len(out_str)}', data=out_str)
+        parent.create_array(ds_name, data=np.array(out_str, dtype=f'S{len(out_str)}'))
         print(f"[DEBUG] => wrote JSON to {out_path}: {out_str.decode('utf-8')}")
         # Optionally print Zarr structure
         print("[DEBUG] Zarr top-level keys:", list(zf.keys()))

--- a/tissue_segmentation/TotalSegmentator/requirements.txt
+++ b/tissue_segmentation/TotalSegmentator/requirements.txt
@@ -2,7 +2,7 @@ fastapi>=0.104.1
 uvicorn[standard]>=0.24.0
 pydantic>=2.4.0
 sse-starlette>=1.6.5
-zarr>=2.17.0
+zarr==3.1.5
 numpy==1.26.4
 nibabel>=5.1.0
 dicom2nifti>=2.4.0

--- a/tissue_segmentation/TotalSegmentator/totalsegmentator_tasknode.py
+++ b/tissue_segmentation/TotalSegmentator/totalsegmentator_tasknode.py
@@ -785,11 +785,10 @@ def save_organ_to_zarr(organ_name: str, organ_data: np.ndarray, zarr_path: str, 
 
         # Create organ dataset in voxel_mask group
         print(f"[Zarr] Creating dataset with shape {organ_data.shape}")
-        organ_dataset = voxel_group.create_dataset(
+        organ_dataset = voxel_group.create_array(
             dataset_name,
             data=organ_data,
-            compressor=zarr.Zlib(level=3),  # Zarr uses compressor instead of compression
-            chunks=True
+            compressors=[zarr.codecs.GzipCodec(level=3)],
         )
         print(f"[Zarr] Dataset created successfully")
 

--- a/tissue_segmentation/VISTA-PATH/VISTA_Node.py
+++ b/tissue_segmentation/VISTA-PATH/VISTA_Node.py
@@ -186,7 +186,7 @@ def _put_str_dataset(grp, key: str, value: str):
         b = b" "
     if key in grp:
         del grp[key]
-    grp.create_array(key, data=np.frombuffer(b, dtype=f"S{len(b)}"), dtype=f"S{len(b)}")
+    grp.create_array(key, data=np.frombuffer(b, dtype=f"S{len(b)}"))
 
 def compute_grid(width: int, height: int, patch_size: int, stride: int):
     """
@@ -293,7 +293,6 @@ def tile_slide_incrementally(
         user_data_grp.create_array(
             "path",
             data=np.frombuffer(path_bytes, dtype=f"S{len(path_bytes)}"),
-            dtype=f"S{len(path_bytes)}"
         )
 
         # save tiling parameters
@@ -309,7 +308,6 @@ def tile_slide_incrementally(
         user_data_grp.create_array(
             "tiling_params",
             data=np.frombuffer(param_bytes, dtype=f"S{len(param_bytes)}"),
-            dtype=f"S{len(param_bytes)}"
         )
 
         # get downsample factor
@@ -1108,8 +1106,8 @@ def run_segmentation_sequential(args) -> Dict[str, Any]:
             classes_grp = out_grp.create_group("classes")
             names_ascii = np.array([str(n).encode("utf-8") for n in class_names], dtype="S256")
             colors_ascii = np.array([c.encode("utf-8") for c in class_colors], dtype="S256")
-            classes_grp.create_array("name", data=names_ascii, dtype="S256")
-            classes_grp.create_array("color", data=colors_ascii, dtype="S256")
+            classes_grp.create_array("name", data=names_ascii)
+            classes_grp.create_array("color", data=colors_ascii)
 
             # userData provenance: model + run config so other TissueSeg models reuse the layout
             user_data_grp = out_grp.create_group("userData")
@@ -1142,6 +1140,7 @@ def run_segmentation_sequential(args) -> Dict[str, Any]:
         import traceback
         traceback.print_exc()
         raise
+
 
 
 
@@ -1530,7 +1529,7 @@ def execute_node():
         # use create_dataset to create scalar array (string data)
         # convert bytes to numpy array
         out_array = np.frombuffer(out_bytes, dtype=f'S{len(out_bytes)}')
-        zf.create_array(node_out_path, data=out_array, dtype=f'S{len(out_bytes)}')
+        zf.create_array(node_out_path, data=out_array)
 
     progress_value = 0  # 归零，上一个人 execute 结束
     return {"status": "ok", "output": out}

--- a/tissue_segmentation/VISTA-PATH/VISTA_Node.py
+++ b/tissue_segmentation/VISTA-PATH/VISTA_Node.py
@@ -186,7 +186,7 @@ def _put_str_dataset(grp, key: str, value: str):
         b = b" "
     if key in grp:
         del grp[key]
-    grp.create_dataset(key, shape=(), dtype=f"S{len(b)}", data=b)
+    grp.create_array(key, data=np.frombuffer(b, dtype=f"S{len(b)}"), dtype=f"S{len(b)}")
 
 def compute_grid(width: int, height: int, patch_size: int, stride: int):
     """
@@ -264,21 +264,21 @@ def tile_slide_incrementally(
         grp = root.create_group(zarr_group)
 
         # create datasets
-        images_ds = grp.create_dataset(
+        images_ds = grp.create_array(
             "images",
             shape=(N, patch_size, patch_size, 3),
             chunks=(chunk_size, patch_size, patch_size, 3),
             dtype="uint8",
         )
 
-        patch_id_ds = grp.create_dataset(
+        patch_id_ds = grp.create_array(
             "patch_id",
             shape=(N,),
             chunks=(chunk_size,),
             dtype="int64",
         )
 
-        coords_ds = grp.create_dataset(
+        coords_ds = grp.create_array(
             "coordinates",
             shape=(N, 4),
             chunks=(chunk_size, 4),
@@ -290,7 +290,7 @@ def tile_slide_incrementally(
 
         # save WSI path
         path_bytes = wsi_path.encode("utf-8")
-        user_data_grp.create_dataset(
+        user_data_grp.create_array(
             "path",
             data=np.frombuffer(path_bytes, dtype=f"S{len(path_bytes)}"),
             dtype=f"S{len(path_bytes)}"
@@ -306,7 +306,7 @@ def tile_slide_incrementally(
         }
         param_str = json.dumps(tiling_params)
         param_bytes = param_str.encode("utf-8")
-        user_data_grp.create_dataset(
+        user_data_grp.create_array(
             "tiling_params",
             data=np.frombuffer(param_bytes, dtype=f"S{len(param_bytes)}"),
             dtype=f"S{len(param_bytes)}"
@@ -420,21 +420,21 @@ def create_segnode_zarr(
     grp = root.create_group(zarr_group)
 
     # create datasets
-    images_ds = grp.create_dataset(
+    images_ds = grp.create_array(
         "images",
         shape=(N, patch_size, patch_size, 3),
         chunks=(chunk_size, patch_size, patch_size, 3),
         dtype="uint8",
     )
 
-    patch_id_ds = grp.create_dataset(
+    patch_id_ds = grp.create_array(
         "patch_id",
         shape=(N,),
         chunks=(chunk_size,),
         dtype="int64",
     )
 
-    coords_ds = grp.create_dataset(
+    coords_ds = grp.create_array(
         "coordinates",
         shape=(N, 4),
         chunks=(chunk_size, 4),
@@ -446,11 +446,9 @@ def create_segnode_zarr(
 
     # save WSI path
     path_bytes = wsi_path.encode("utf-8")
-    user_data_grp.create_dataset(
+    user_data_grp.create_array(
         "path",
-        shape=(),
-        dtype=f"S{len(path_bytes)}",
-        data=path_bytes,
+        data=np.array(path_bytes, dtype=f"S{len(path_bytes)}"),
     )
 
     # save tiling parameters
@@ -463,11 +461,9 @@ def create_segnode_zarr(
         "chunk_size": chunk_size,
     }
     tiling_bytes = json.dumps(tiling_params, ensure_ascii=False).encode("utf-8")
-    user_data_grp.create_dataset(
+    user_data_grp.create_array(
         "tiling_params",
-        shape=(),
-        dtype=f"S{len(tiling_bytes)}",
-        data=tiling_bytes,
+        data=np.array(tiling_bytes, dtype=f"S{len(tiling_bytes)}"),
     )
 
     # get downsample factor
@@ -596,16 +592,16 @@ def generate_dzi_tiles_to_zarr(full_mask, zarr_path, dzi_group_path, slide_name,
         # Create zarr dataset for this level
         # Store as (num_tiles, tile_size, tile_size, 4) RGBA
         level_grp = dzi_grp.create_group(f"L{dzi_level}")
-        tiles_ds = level_grp.create_dataset(
+        tiles_ds = level_grp.create_array(
             "tiles",
             shape=(num_tiles, tile_size, tile_size, 4),
             chunks=(1, tile_size, tile_size, 4),
             dtype='uint8',
-            compressor=zarr.Blosc(cname='zstd', clevel=3, shuffle=zarr.Blosc.SHUFFLE)
+            compressors=[zarr.codecs.BloscCodec(cname='zstd', clevel=3)]
         )
         
         # Create tile index mapping: stores (tile_x, tile_y) for each tile
-        tile_coords_ds = level_grp.create_dataset(
+        tile_coords_ds = level_grp.create_array(
             "tile_coords",
             shape=(num_tiles, 2),
             chunks=(min(1000, num_tiles), 2),
@@ -623,11 +619,9 @@ def generate_dzi_tiles_to_zarr(full_mask, zarr_path, dzi_group_path, slide_name,
         }
         meta_str = json.dumps(level_meta, ensure_ascii=False)
         meta_bytes = meta_str.encode('utf-8')
-        level_grp.create_dataset(
+        level_grp.create_array(
             "meta",
-            shape=(),
-            dtype=f'S{len(meta_bytes)}',
-            data=meta_bytes
+            data=np.array(meta_bytes, dtype=f'S{len(meta_bytes)}')
         )
         
         # Generate and save tiles
@@ -692,11 +686,9 @@ def generate_dzi_tiles_to_zarr(full_mask, zarr_path, dzi_group_path, slide_name,
     }
     meta_str = json.dumps(meta, indent=2, ensure_ascii=False)
     meta_bytes = meta_str.encode('utf-8')
-    dzi_grp.create_dataset(
+    dzi_grp.create_array(
         "meta",
-        shape=(),
-        dtype=f'S{len(meta_bytes)}',
-        data=meta_bytes
+        data=np.array(meta_bytes, dtype=f'S{len(meta_bytes)}')
     )
     
     print(f"[INFO] DZI tiles metadata saved to zarr: {dzi_group_path}/meta")
@@ -1096,13 +1088,12 @@ def run_segmentation_sequential(args) -> Dict[str, Any]:
                 sub = _sanitize_class_name(tissue_display)
                 tissue_grp = masks_grp.create_group(sub)
                 binary_mask = (full_mask > 0).astype(bool)
-                tissue_grp.create_dataset(
+                tissue_grp.create_array(
                     "mask",
                     data=binary_mask,
-                    shape=(level_height, level_width),
                     chunks=(min(1024, level_height), min(1024, level_width)),
                     dtype=bool,
-                    compressor=zarr.Blosc(cname='zstd', clevel=3, shuffle=zarr.Blosc.BITSHUFFLE)
+                    compressors=[zarr.codecs.BloscCodec(cname='zstd', clevel=3)]
                 )
                 print(f"[{NODE_NAME}] Mask saved: masks/{sub}/mask {level_height}x{level_width} (bool)")
 
@@ -1117,8 +1108,8 @@ def run_segmentation_sequential(args) -> Dict[str, Any]:
             classes_grp = out_grp.create_group("classes")
             names_ascii = np.array([str(n).encode("utf-8") for n in class_names], dtype="S256")
             colors_ascii = np.array([c.encode("utf-8") for c in class_colors], dtype="S256")
-            classes_grp.create_dataset("name", shape=(len(names_ascii),), dtype="S256", data=names_ascii)
-            classes_grp.create_dataset("color", shape=(len(colors_ascii),), dtype="S256", data=colors_ascii)
+            classes_grp.create_array("name", data=names_ascii, dtype="S256")
+            classes_grp.create_array("color", data=colors_ascii, dtype="S256")
 
             # userData provenance: model + run config so other TissueSeg models reuse the layout
             user_data_grp = out_grp.create_group("userData")
@@ -1151,6 +1142,7 @@ def run_segmentation_sequential(args) -> Dict[str, Any]:
         import traceback
         traceback.print_exc()
         raise
+
 
 
 # ======================= API routes =======================
@@ -1538,7 +1530,7 @@ def execute_node():
         # use create_dataset to create scalar array (string data)
         # convert bytes to numpy array
         out_array = np.frombuffer(out_bytes, dtype=f'S{len(out_bytes)}')
-        zf.create_dataset(node_out_path, data=out_array, dtype=f'S{len(out_bytes)}')
+        zf.create_array(node_out_path, data=out_array, dtype=f'S{len(out_bytes)}')
 
     progress_value = 0  # 归零，上一个人 execute 结束
     return {"status": "ok", "output": out}

--- a/tissue_segmentation/VISTA-PATH/VISTA_Node.py
+++ b/tissue_segmentation/VISTA-PATH/VISTA_Node.py
@@ -21,6 +21,12 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import zarr
 import uvicorn
+
+# Silence zarr v3 "unstable data type" warnings (structured arrays + fixed-length
+# string/bytes dtypes used by our schema). No cross-library portability needed.
+import warnings
+from zarr.errors import UnstableSpecificationWarning
+warnings.filterwarnings("ignore", category=UnstableSpecificationWarning)
 import torch
 from torch.utils.data import Dataset, DataLoader
 from PIL import Image

--- a/tissue_segmentation/VISTA-PATH/get_patches.py
+++ b/tissue_segmentation/VISTA-PATH/get_patches.py
@@ -114,7 +114,7 @@ def create_segnode_zarr(
 
     # Create datasets
     # images: (N, patch_size, patch_size, 3) uint8
-    images_ds = grp.create_dataset(
+    images_ds = grp.create_array(
         "images",
         shape=(N, patch_size, patch_size, 3),
         chunks=(chunk_size, patch_size, patch_size, 3),
@@ -122,7 +122,7 @@ def create_segnode_zarr(
     )
 
     # patch_id: simply 0..N-1
-    patch_id_ds = grp.create_dataset(
+    patch_id_ds = grp.create_array(
         "patch_id",
         shape=(N,),
         chunks=(chunk_size,),
@@ -130,7 +130,7 @@ def create_segnode_zarr(
     )
 
     # coordinates: (N,4) -> [x0,y0,x1,y1] in level coordinates
-    coords_ds = grp.create_dataset(
+    coords_ds = grp.create_array(
         "coordinates",
         shape=(N, 4),
         chunks=(chunk_size, 4),
@@ -142,11 +142,9 @@ def create_segnode_zarr(
 
     # Save original wsi path
     path_bytes = wsi_path.encode("utf-8")
-    user_data_grp.create_dataset(
+    user_data_grp.create_array(
         "path",
-        shape=(),
-        dtype=f"S{len(path_bytes)}",
-        data=path_bytes,
+        data=np.array(path_bytes, dtype=f"S{len(path_bytes)}"),
     )
 
     # Save tiling parameters as JSON
@@ -159,11 +157,9 @@ def create_segnode_zarr(
         "chunk_size": chunk_size,
     }
     tiling_bytes = json.dumps(tiling_params, ensure_ascii=False).encode("utf-8")
-    user_data_grp.create_dataset(
+    user_data_grp.create_array(
         "tiling_params",
-        shape=(),
-        dtype=f"S{len(tiling_bytes)}",
-        data=tiling_bytes,
+        data=np.array(tiling_bytes, dtype=f"S{len(tiling_bytes)}"),
     )
 
     # We also save a default SegNode config placeholder, for example:
@@ -181,11 +177,9 @@ def create_segnode_zarr(
         # "tissue_colors": ["#000000", "#FF0000"],
     }
     cfg_bytes = json.dumps(default_config, ensure_ascii=False).encode("utf-8")
-    user_data_grp.create_dataset(
+    user_data_grp.create_array(
         "SegNode_config",
-        shape=(),
-        dtype=f"S{len(cfg_bytes)}",
-        data=cfg_bytes,
+        data=np.array(cfg_bytes, dtype=f"S{len(cfg_bytes)}"),
     )
 
     # Precompute downsample factor from base level to chosen level


### PR DESCRIPTION
## Summary
### Zarr v3 migration

- Replace `create_dataset` with `create_array` across task nodes and migration scripts.
- Standardize Zarr group access (`zarr.open_group(..., mode=...)`) and simplify array creation by inferring dtypes from input data where possible.
- Pin **`zarr==3.1.5`** in affected module requirements for consistency.
- Suppress Zarr v3 `UnstableSpecificationWarning` noise from fixed-length string / structured arrays.
- Update migration utilities (`migrate_*_groups.py`, `rename_class_counts_to_cell.py`) to use the new array APIs.

**Modules updated:** NuClass, CellPose, StarDist, InstanSeg, H-optimus, MUSK, Virchow, PLIP/CONCH requirements, Ark Plus, Cardiac, BiomedParse, SAM, TotalSegmentator, VISTA-PATH, and related scripts.